### PR TITLE
Add triton status and post-setup tables.

### DIFF
--- a/sql/conch.sql
+++ b/sql/conch.sql
@@ -210,7 +210,7 @@ CREATE TABLE triton_post_setup_stage (
     id                  uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
     product_id          uuid        REFERENCES hardware_product (id),
     name                text        NOT NULL UNIQUE,
-    requires            uuid        REFERENCES triton_post_setup_stage (id),
+    requires            text,       -- This should be a list of uuids this stage requires before running.
     description         text,
     created             timestamptz NOT NULL DEFAULT current_timestamp,
 );


### PR DESCRIPTION
This allows us to track server status in Triton, as well as which stage of post-setup a given server is at. A log table is also created to capture logs as needed. (Which we might want to surface to the operator directly, rather than going through syslog.)