### PR TITLE
Make each rack row uniuqe in datacenter_rack_layout, with migration

### DIFF
--- a/sql/conch.sql
+++ b/sql/conch.sql
@@ -95,7 +95,8 @@ CREATE TABLE datacenter_rack_layout (
     product_id          uuid        NOT NULL REFERENCES hardware_product (id),
     ru_start            integer     NOT NULL,
     created             timestamptz NOT NULL DEFAULT current_timestamp,
-    updated             timestamptz NOT NULL DEFAULT current_timestamp
+    updated             timestamptz NOT NULL DEFAULT current_timestamp,
+    UNIQUE ( rack_id, ru_start )
 );
 
 -- Define regional subnets.

--- a/sql/migrations/0002-add-unique-constraint-to-rack-layout.sql
+++ b/sql/migrations/0002-add-unique-constraint-to-rack-layout.sql
@@ -1,0 +1,3 @@
+SELECT run_migration(2, $$
+  ALTER TABLE datacenter_rack_layout ADD UNIQUE ( rack_id, ru_start );
+$$);


### PR DESCRIPTION
So we don't accidentally have multiple rows in the layout table, somehow.