### PR TITLE
Store local IP of Relay device

### DIFF
--- a/Conch/lib/Conch/Control/Relay.pm
+++ b/Conch/lib/Conch/Control/Relay.pm
@@ -37,13 +37,16 @@ sub list_relays {
 }
 
 sub register_relay {
-  my ($schema, $serial, $ip, $attrib) = @_;
+  my ($schema, $serial, $client_ip, $attrib) = @_;
+
+  # XXX $client_ip is where the request comes from, which is probably a NAT.
+  # XXX We should store that! But the actual Relay IP is in the attrib hash.
 
   info "Registering relay device $serial";
 
   my $relay = $schema->resultset('Relay')->update_or_create({
     id        => $serial,
-    ipaddr    => $ip,
+    ipaddr    => $attrib->{ipaddr} || undef,
     version   => $attrib->{version},
     ssh_port  => $attrib->{ssh_port},
     updated   => \'NOW()'

--- a/Conch/lib/Conch/Route/Relay.pm
+++ b/Conch/lib/Conch/Route/Relay.pm
@@ -28,7 +28,7 @@ get '/relay/active' => needs admin => sub {
 
 # This acts as both an initial registration and heartbeat endpoint.
 post '/relay/:serial/register' => needs integrator => sub {
-  my $ip = request->address;
+  my $client_ip = request->address;
   my $serial = param 'serial';
   my $user_name = session->read('integrator');
   my $attrib = body_parameters->as_hashref;
@@ -37,7 +37,7 @@ post '/relay/:serial/register' => needs integrator => sub {
 
   my $relay = process sub {
     connect_user_relay(schema, $user_name, $serial);
-    return register_relay(schema, $serial, $ip, $attrib)
+    return register_relay(schema, $serial, $client_ip, $attrib)
   };
 
   if ($relay) {


### PR DESCRIPTION
Stores the passed `wlan0` IP from the Relays in the `relay.ipaddr` table.

(This is mostly helpful for debugging and development, though we might later use it for cross-Relay orchestration.)