### PR TITLE
Change ram_total values from MB to GB

### DIFF
--- a/sql/hardware_profiles.sql
+++ b/sql/hardware_profiles.sql
@@ -10,7 +10,7 @@ INSERT INTO hardware_product_profile ( product_id, purpose, bios_firmware, cpu_n
             rack_unit )
        VALUES (  ( SELECT id FROM hardware_product WHERE name = 'Joyent-Storage-Platform-7001' ),
             'Manta Object Store', 'American Megatrends Inc. 2.0a', 2, 'Intel(R) Xeon(R) CPU E5-2690 v4 @ 2.60GHz',
-            16, 516929, 7, 35, 7452.04, 1, 93.16, '0', 2,
+            16, 512, 7, 35, 7452.04, 1, 93.16, '0', 2,
             ( SELECT id FROM zpool_profile WHERE name = 'Joyent-Storage-Platform-7001' ),
             4
        );
@@ -20,7 +20,7 @@ INSERT INTO hardware_product_profile ( product_id, purpose, bios_firmware, cpu_n
             rack_unit )
        VALUES (  ( SELECT id FROM hardware_product WHERE name = 'Joyent-Storage-Platform-7201' ),
             'Mass Storage', 'American Megatrends Inc. 2.0a', 2, 'Intel(R) Xeon(R) CPU E5-2690 v4 @ 2.60GHz',
-            16, 516929, 7, 35, 7452.04, 1, 93.16, '0', 2,
+            16, 512, 7, 35, 7452.04, 1, 93.16, '0', 2,
             ( SELECT id FROM zpool_profile WHERE name = 'Joyent-Storage-Platform-7201' ),
             4
         );
@@ -30,7 +30,7 @@ INSERT INTO hardware_product_profile ( product_id, purpose, bios_firmware, cpu_n
             rack_unit )
       VALUES (  ( SELECT id FROM hardware_product WHERE name = 'Joyent-Compute-Platform-3301' ),
             'General Compute', 'Dell Inc. 2.2.5', 2, 'Intel(R) Xeon(R) CPU E5-2690 v4 @ 2.60GHz',
-            16, 258372, 7, 15, 1117.81, 1, 93.16, '0', 2,
+            16, 256, 7, 15, 1117.81, 1, 93.16, '0', 2,
             ( SELECT id FROM zpool_profile WHERE name = 'Joyent-Compute-Platform-3301' ),
             2
        );
@@ -40,7 +40,7 @@ INSERT INTO hardware_product_profile ( product_id, purpose, bios_firmware, cpu_n
             rack_unit )
       VALUES (  ( SELECT id FROM hardware_product WHERE name = 'Joyent-Compute-Platform-3302' ),
             'SSD Compute', 'Dell Inc. 2.2.5', 2, 'Intel(R) Xeon(R) CPU E5-2690 v4 @ 2.60GHz',
-            16, 258372, 7, 0, 16, 1490.42, '0-15', 2,
+            16, 256, 7, 0, 16, 1490.42, '0-15', 2,
             ( SELECT id FROM zpool_profile WHERE name = 'Joyent-Compute-Platform-3302' AND disk_per = 16 ),
             2
        );
@@ -50,6 +50,6 @@ INSERT INTO hardware_product_profile ( product_id, purpose, bios_firmware, cpu_n
             rack_unit )
       VALUES (  ( SELECT id FROM hardware_product WHERE name = 'CERES' ),
             'CPG Compute', 'Dell Inc. 2.2.5', 2, 'Intel(R) Xeon(R) CPU E5-2690 v4 @ 2.60GHz',
-            16, 258372, 7, 15, 1117.81, 1, 93.16, '0', 2,
+            16, 256, 7, 15, 1117.81, 1, 93.16, '0', 2,
             2
        );


### PR DESCRIPTION
This is related to https://github.com/joyent/conch-livesys/pull/13, which changes `ram_total` from MB to GB (pulled directly from the BIOS/DIMM info.)