### PR TITLE
Validate what is available in the device report

### DIFF
--- a/Conch/lib/Conch/Control/Device/Configuration.pm
+++ b/Conch/lib/Conch/Control/Device/Configuration.pm
@@ -29,7 +29,7 @@ sub validate_product {
     trace("$device_id: OK: Product name set: $product_name_log");
   }
 
-  $schema->resultset('DeviceValidate')->update_or_create({
+  $schema->resultset('DeviceValidate')->create({
     device_id       => $device_id,
     report_id       => $report_id,
     validation      => encode_json({

--- a/Conch/lib/Conch/Control/Device/Environment.pm
+++ b/Conch/lib/Conch/Control/Device/Environment.pm
@@ -51,7 +51,7 @@ sub validate_cpu_temp {
 
      info($cpu_msg);
 
-     my $device_validate = $schema->resultset('DeviceValidate')->update_or_create({
+     my $device_validate = $schema->resultset('DeviceValidate')->create({
        device_id       => $device_id,
        report_id       => $report_id,
        validation => encode_json({
@@ -131,7 +131,7 @@ sub validate_disk_temp {
 
      trace "$device_id: report $report_id: " . $disk->id . ": ". $disk->serial_number . ": " . $disk_msg;
 
-     my $device_validate = $schema->resultset('DeviceValidate')->update_or_create({
+     my $device_validate = $schema->resultset('DeviceValidate')->create({
        device_id       => $device_id,
        report_id       => $report_id,
        validation => encode_json({

--- a/Conch/lib/Conch/Control/Device/Inventory.pm
+++ b/Conch/lib/Conch/Control/Device/Inventory.pm
@@ -32,7 +32,7 @@ sub validate_system {
     trace ("$device_id: report $report_id: OK: Correct CPU count: $cpu_num_log");
   }
 
-  $schema->resultset('DeviceValidate')->update_or_create({
+  $schema->resultset('DeviceValidate')->create({
     device_id       => $device_id,
     report_id       => $report_id,
     validation      => encode_json({
@@ -56,7 +56,7 @@ sub validate_system {
     trace("$device_id: report $report_id: OK: Correct DIMM count: $dimms_num_log");
   }
 
-  $schema->resultset('DeviceValidate')->update_or_create({
+  $schema->resultset('DeviceValidate')->create({
     device_id       => $device_id,
     report_id       => $report_id,
     validation      => encode_json({
@@ -80,7 +80,7 @@ sub validate_system {
     trace("$device_id: report $report_id: OK: Correct RAM total: $ram_total_log");
   }
 
-  $schema->resultset('DeviceValidate')->update_or_create({
+  $schema->resultset('DeviceValidate')->create({
     device_id       => $device_id,
     report_id       => $report_id,
     validation      => encode_json({
@@ -104,7 +104,7 @@ sub validate_system {
     trace("$device_id: report $report_id: OK: Correct number of network interfacesl: $nics_num_log");
   }
 
-  $schema->resultset('DeviceValidate')->update_or_create({
+  $schema->resultset('DeviceValidate')->create({
     device_id       => $device_id,
     report_id       => $report_id,
     validation      => encode_json({
@@ -176,7 +176,7 @@ sub validate_disks {
     trace("$device_id: report $report_id: OK: Correct number of USB_HDD: $usb_hdd_num_log");
   }
 
-  $schema->resultset('DeviceValidate')->update_or_create({
+  $schema->resultset('DeviceValidate')->create({
     device_id       => $device_id,
     report_id       => $report_id,
     validation      => encode_json({
@@ -200,7 +200,7 @@ sub validate_disks {
     trace("$device_id: report $report_id: OK: Correct number of SAS_HDD: $sas_hdd_num_log");
   }
 
-  $schema->resultset('DeviceValidate')->update_or_create({
+  $schema->resultset('DeviceValidate')->create({
     device_id       => $device_id,
     report_id       => $report_id,
     validation      => encode_json({
@@ -239,7 +239,7 @@ sub validate_disks {
     trace("$device_id: report $report_id: OK: Correct number of SAS_SSD: $sas_ssd_num_log");
   }
 
-   $schema->resultset('DeviceValidate')->update_or_create({
+   $schema->resultset('DeviceValidate')->create({
     device_id       => $device_id,
     report_id       => $report_id,
     validation      => encode_json({
@@ -263,7 +263,7 @@ sub validate_disks {
       trace("$device_id: report $report_id: OK: ZFS SLOG is in correct slot: $slog_slot_log");
     }
 
-    $schema->resultset('DeviceValidate')->update_or_create({
+    $schema->resultset('DeviceValidate')->create({
       device_id       => $device_id,
       report_id       => $report_id,
       validation      => encode_json({

--- a/Conch/lib/Conch/Control/Device/Network.pm
+++ b/Conch/lib/Conch/Control/Device/Network.pm
@@ -42,7 +42,7 @@ sub validate_links {
      $nic_state_status = 1;
    }
 
-   $schema->resultset('DeviceValidate')->update_or_create({
+   $schema->resultset('DeviceValidate')->create({
      device_id       => $device_id,
      report_id       => $report_id,
      validation      => encode_json({
@@ -93,7 +93,7 @@ sub validate_wiremap {
       mistake $nic_peer_log;
     }
 
-    $schema->resultset('DeviceValidate')->update_or_create({
+    $schema->resultset('DeviceValidate')->create({
       device_id       => $device_id,
       report_id       => $report_id,
       validation      => encode_json({
@@ -122,7 +122,7 @@ sub validate_wiremap {
     mistake $num_switch_log;
   }
 
-  $schema->resultset('DeviceValidate')->update_or_create({
+  $schema->resultset('DeviceValidate')->create({
       device_id       => $device_id,
       report_id       => $report_id,
       validation      => encode_json({
@@ -152,7 +152,7 @@ sub validate_wiremap {
       mistake $num_ports_log;
     }
 
-    $schema->resultset('DeviceValidate')->update_or_create({
+    $schema->resultset('DeviceValidate')->create({
         device_id       => $device_id,
         report_id       => $report_id,
         validation      => encode_json({
@@ -187,6 +187,5 @@ sub port_numbers {
   my $second_port = $first_port + 19;
   return ("1/$first_port", "1/$second_port");
 }
-
 
 1;

--- a/Conch/lib/Conch/Control/Device/Validation.pm
+++ b/Conch/lib/Conch/Control/Device/Validation.pm
@@ -12,19 +12,19 @@ use Exporter 'import';
 our @EXPORT = qw( validate_device );
 
 sub validate_device {
-  my ($schema, $device, $report_id) = @_;
+  my ($schema, $device, $device_report, $report_id) = @_;
 
   # all of the validation functions to run
   # validation function should have the following signature:
   # `my ($schema, $device, $report_id) = @_;`
   my @validations = (
     \&validate_cpu_temp,
-    \&validate_disk_temp,
     \&validate_product,
     \&validate_system,
-    \&validate_disks,
-    \&validate_links,
-    \&validate_wiremap,
+    $device_report->disks ? \&validate_disk_temp : (),
+    $device_report->disks ? \&validate_disks : (),
+    $device_report->interfaces ? \&validate_links : (),
+    $device_report->interfaces ? \&validate_wiremap : (),
 
   );
 

--- a/Conch/lib/Conch/Data/DeviceReport.pm
+++ b/Conch/lib/Conch/Data/DeviceReport.pm
@@ -7,12 +7,6 @@ use MooseX::Storage;
 
 with Storage('format' => 'JSON');
 
-#subtype 'StrDateTime',
-  #as 'DateTime';
-
-#coerce 'StringDateTime',
-  #from 'Str',
-  #via { [ $_ ] };
 
 
 has 'product_name' => (
@@ -40,7 +34,7 @@ has 'state' => (
 );
 
 has 'interfaces' => (
-  required => 1,
+  required => 0,
   is => 'ro',
   # hash can contain undef values
   isa => 'HashRef[HashRef[Maybe[Str]]]'
@@ -65,13 +59,13 @@ has 'memory' => (
 );
 
 has 'disks' => (
-  required => 1,
+  required => 0,
   is => 'ro',
   isa => 'HashRef[HashRef[Value]]'
 );
 
 has 'temp' => (
-  required => 1,
+  required => 0,
   is => 'ro',
   isa => 'HashRef[Int]'
 );
@@ -84,7 +78,7 @@ has 'relay' => (
 );
 
 has 'uptime_since' => (
-  required => 1,
+  required => 0,
   is => 'ro',
   isa => 'Str'
 );

--- a/Conch/lib/Conch/Route/Device.pm
+++ b/Conch/lib/Conch/Route/Device.pm
@@ -92,8 +92,7 @@ post '/device/:serial' => needs integrator => sub {
   my $user_name = session->read('integrator');
   my $serial    = param 'serial';
 
-  my $device;
-  my $report_id;
+  my ($device, $report_id, $device_report);
 
   # NOTE This stops reports being ingested until the device is slotted into a rack.
   #      This may not be desireable. Once the device is entered into device_location
@@ -111,9 +110,8 @@ post '/device/:serial' => needs integrator => sub {
   #  warning "$user_name not allowed to view device $serial or $serial does not exist";
   #  return status_401('unauthorized');
   #}
-
   try {
-    my $device_report = parse_device_report(body_parameters->as_hashref);
+    $device_report = parse_device_report(body_parameters->as_hashref);
     ($device, $report_id) = record_device_report( schema, $device_report);
     connect_user_relay(schema, $user_name, $device_report->relay->{serial})
       if $device_report->relay;
@@ -123,7 +121,7 @@ post '/device/:serial' => needs integrator => sub {
     return status_400("@err");
   }
 
-  my $validation = validate_device(schema, $device, $report_id);
+  my $validation = validate_device(schema, $device, $device_report, $report_id);
   if ($validation) {
       status_200({
           device_id => $device->id,


### PR DESCRIPTION
Validate what is available in a device report.

Currently, the only optional validations are those dealing with disks and interfaces. The pattern is established to enable other things to become optional. 

Also removes an unnecessary lookup that was showing up in the slow query log when we write to the `device_validate` table.