### PR TITLE
Restrict relay access

### DIFF
--- a/Conch/lib/Conch/Control/User.pm
+++ b/Conch/lib/Conch/Control/User.pm
@@ -7,13 +7,20 @@ use Dancer2 appname => 'Conch';
 use Dancer2::Plugin::Passphrase;
 
 use Exporter 'import';
-our @EXPORT = qw( lookup_user_by_name authenticate create_integrator_user create_admin_passphrase );
+our @EXPORT = qw( lookup_user_by_name user_id_by_name authenticate create_integrator_user create_admin_passphrase );
 
 sub lookup_user_by_name {
   my ($schema, $name) = @_;
-  return $schema->resultset('UserAccount')->search({
+  return $schema->resultset('UserAccount')->find({
     name => $name
-  })->single;
+  });
+};
+
+sub user_id_by_name {
+  my ($schema, $name) = @_;
+  return $schema->resultset('UserAccount')->find(
+    { name => $name }, { columns => 'id' }
+  )->id;
 };
 
 sub authenticate {

--- a/Conch/lib/Conch/Route/Relay.pm
+++ b/Conch/lib/Conch/Route/Relay.pm
@@ -16,13 +16,15 @@ set serializer => 'JSON';
 
 # Returns all relay devices and their status.
 get '/relay' => needs integrator => sub {
-  my @relays = list_relays(schema);
+  my $user_name = session->read('integrator');
+  my @relays = list_user_relays(schema, $user_name);
   status_200(\@relays);
 };
 
 # Returns all active relay devices and their status.
 get '/relay/active' => needs integrator => sub {
-  my @relays = list_relays(schema, 2);
+  my $user_name = session->read('integrator');
+  my @relays = list_user_relays(schema, $user_name, 2);
   status_200(\@relays);
 };
 


### PR DESCRIPTION
Restrict a user's relay access to see only relays that have registered or reported with the user's credentials in the past week.