### PR TITLE
Store auxiliary data in the Device Report

### DIFF
--- a/Conch/lib/Conch/Control/DeviceReport.pm
+++ b/Conch/lib/Conch/Control/DeviceReport.pm
@@ -17,17 +17,24 @@ our @EXPORT = qw( parse_device_report record_device_report );
 # Parse a DeviceReport object from a HashRef and report all validation errors
 sub parse_device_report {
   my $report = shift;
-  $report->{raw} = dclone($report);
+  my $aux_report = dclone($report);
 
   my $dr;
   eval {
     $dr = Conch::Data::DeviceReport->new($report);
   };
+
   if ($@) {
     my $errs = join("; ", map { $_->message } $@->errors);
     error "Error validating device report: $errs";
   }
   else {
+    for my $attr (keys %{ $dr->pack() }) {
+      delete $aux_report->{$attr};
+    }
+    if ( %{ $aux_report }) {
+      $dr->{aux} = $aux_report;
+    }
     return $dr;
   }
 }

--- a/Conch/lib/Conch/Data/DeviceReport.pm
+++ b/Conch/lib/Conch/Data/DeviceReport.pm
@@ -83,9 +83,10 @@ has 'uptime_since' => (
   isa => 'Str'
 );
 
-has 'raw' => (
-  required => 1,
-  is => 'ro',
+# Store auxillary data in the report. This is data that might be used later.
+has 'aux' => (
+  required => 0,
+  is => 'rw',
   isa => 'HashRef[Any]'
 );
 


### PR DESCRIPTION
If there's any extra data given in a device report, store it for later.

Does not store redundant data.