### PR TITLE
Add indicator for validated hosts, store validation denormalized

### DIFF
--- a/Conch/lib/Conch/Control/Device.pm
+++ b/Conch/lib/Conch/Control/Device.pm
@@ -18,6 +18,7 @@ our @EXPORT = qw( device_info device_location all_user_devices devices_for_user
                   update_device_location delete_device_location
                   get_validation_criteria get_active_devices
                   get_devices_by_health unlocated_devices device_response
+                  validate_device
                  );
 
 sub get_validation_criteria {
@@ -282,6 +283,15 @@ sub update_device_location {
     rack_id   => $device_info->{rack},
     rack_unit => $device_info->{rack_unit}
   });
+}
+
+sub validate_device {
+  # $device may be a virtual view
+  my ($schema, $device) = @_;
+  $schema->resultset('Device')
+    ->find({id => $device->id })
+    ->update({validated => \'NOW()', updated => \'NOW()'});
+  return 1;
 }
 
 1;

--- a/Conch/lib/Conch/Route/Device.pm
+++ b/Conch/lib/Conch/Route/Device.pm
@@ -253,7 +253,8 @@ post '/device/:serial/settings/:key' => needs integrator => sub {
 
   my $setting_value = $setting->{$setting_key};
   return status_400("Setting key in request body must match name in the URL ('$setting_key')")
-    unless $setting_value;
+    unless defined $setting_value;
+
   my $status =
     process sub {set_device_setting(schema, $device, $setting_key, $setting_value)};
 

--- a/Conch/lib/Conch/Route/User.pm
+++ b/Conch/lib/Conch/Route/User.pm
@@ -102,7 +102,7 @@ post '/user/me/settings/:key' => needs integrator => sub {
   my $setting_value = $setting->{$setting_key};
 
   return status_400("Setting key in request body must match name in the URL ('$setting_key')")
-    unless $setting_value;
+    unless defined $setting_value;
 
   my $user = lookup_user_by_name(schema, $user_name);
   my $status =

--- a/Conch/lib/Conch/Schema/Result/Device.pm
+++ b/Conch/lib/Conch/Schema/Result/Device.pm
@@ -109,6 +109,11 @@ __PACKAGE__->table("device");
   data_type: 'timestamp with time zone'
   is_nullable: 1
 
+=head2 validated
+
+  data_type: 'timestamp with time zone'
+  is_nullable: 1
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -147,6 +152,8 @@ __PACKAGE__->add_columns(
     original      => { default_value => \"now()" },
   },
   "uptime_since",
+  { data_type => "timestamp with time zone", is_nullable => 1 },
+  "validated",
   { data_type => "timestamp with time zone", is_nullable => 1 },
 );
 
@@ -389,8 +396,8 @@ __PACKAGE__->might_have(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-08-29 16:06:55
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ZsYw/u2f83PRWKYBZqnCtw
+# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-09-15 11:10:34
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:NzPYP1fwov0Yvcumfzpx+A
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/Conch/ui/css/app.css
+++ b/Conch/ui/css/app.css
@@ -375,3 +375,5 @@ ul li {
 .material-icons.md-24 { font-size: 24px; }
 .material-icons.md-36 { font-size: 36px; }
 .material-icons.md-48 { font-size: 48px; }
+
+.green-icon { color: hsl(115, 95%, 40%) }

--- a/Conch/ui/src/views/Device.js
+++ b/Conch/ui/src/views/Device.js
@@ -64,12 +64,15 @@ var deviceReport = {
         );
 
         var healthStatus;
-        if (Device.current.health === 'PASS')
+        if (Device.current.validated && Device.current.health === 'PASS')
             healthStatus =
-                [ Icons.passValidation, t("Device passes validation") ];
+                [ Icons.deviceValidated, t("Device is validated and has been powered off") ];
+        else if (Device.current.health === 'PASS')
+            healthStatus =
+                [ Icons.passValidation, t("Device passes validation tests") ];
         else if (Device.current.health === 'FAIL')
             healthStatus =
-                [ Icons.failValidation, t("Device fails validation") ];
+                [ Icons.failValidation, t("Device fails validation tests") ];
         else
             healthStatus =
                 [ Icons.noReport, t("No reports collected from device") ];

--- a/Conch/ui/src/views/Rack.js
+++ b/Conch/ui/src/views/Rack.js
@@ -165,7 +165,9 @@ var rackLayoutTable = {
                 var occupant = vnode.attrs.occupant;
                 if (occupant) {
                     var healthIcon;
-                    if (occupant.health === 'PASS')
+                    if (occupant.validated && occupant.health === 'PASS')
+                        healthIcon = Icons.deviceValidated;
+                    else if (occupant.health === 'PASS')
                         healthIcon = Icons.passValidation;
                     else if (occupant.health === 'FAIL')
                         healthIcon = Icons.failValidation;

--- a/Conch/ui/src/views/Status.js
+++ b/Conch/ui/src/views/Status.js
@@ -26,6 +26,7 @@ function deviceList(title, isProblem, devices) {
     );
 }
 
+
 module.exports = {
     loading : true,
     oninit : ({state}) => {
@@ -39,19 +40,19 @@ module.exports = {
         var activeDevices   = R.filter(Device.isActive, Device.devices);
         var inactiveDevices = R.filter(R.compose(R.not, Device.isActive), Device.devices);
 
-        var healthCounts   = R.countBy(R.prop('health'));
-        var graduatedCount = R.reduce(function(acc, x) {
-            return R.propIs(String, 'graduated', x) ? acc + 1 : acc;
-        }, 0);
+        var healthCounts   = R.countBy(d => {
+            if (R.propIs(String, 'graduated', d))
+                return 'GRADUATED';
+            if (R.propIs(String, 'validated', d))
+                return 'VALIDATED';
+            return R.prop('health', d);
+        });
 
         var activeHealthCounts   = healthCounts(activeDevices);
-        var activeGraduatedCount = graduatedCount(activeDevices);
 
         var inactiveHealthCounts   = healthCounts(inactiveDevices);
-        var inactiveGraduatedCount = graduatedCount(inactiveDevices);
 
         var totalHealthCounts   = healthCounts(Device.devices);
-        var totalGraduatedCount = graduatedCount(Device.devices);
 
         var deviceHealthGroups = R.groupBy(R.prop('health'), Device.devices);
         return [
@@ -84,11 +85,19 @@ module.exports = {
                       inactiveHealthCounts.PASS || 0,
                       totalHealthCounts.PASS || 0,
                     ],
+
+                    [
+                        t("Validated"),
+                      activeHealthCounts.VALIDATED || 0,
+                      inactiveHealthCounts.VALIDATED || 0,
+                      totalHealthCounts.VALIDATED || 0,
+                    ],
+
                     [
                         t("Graduated"),
-                        activeGraduatedCount,
-                        inactiveGraduatedCount,
-                        totalGraduatedCount
+                      activeHealthCounts.GRADUATED || 0,
+                      inactiveHealthCounts.GRADUATED || 0,
+                      totalHealthCounts.GRADUATED || 0,
                     ],
                     [
                         m("b", t("Sum")),

--- a/Conch/ui/src/views/component/Icons.js
+++ b/Conch/ui/src/views/component/Icons.js
@@ -2,6 +2,12 @@ var m = require('mithril');
 var t = require("i18n4v");
 
 module.exports = {
+    deviceValidated :
+        m("i.material-icons.green-icon", 
+            { title : t("Device validated and powered off. Good to ship.") },
+            "check_circle"
+        ),
+
     passValidation :
         m("i.material-icons", { title : t("Device passes validation") }, "check"),
 

--- a/sql/migrations/0009-device-validated-column.sql
+++ b/sql/migrations/0009-device-validated-column.sql
@@ -1,0 +1,6 @@
+SELECT run_migration(9, $$
+
+    ALTER TABLE device ADD COLUMN validated timestamptz;
+
+$$);
+


### PR DESCRIPTION
When the setting `build.validated` is set for a device, store the timestamp when it was validated in the  `device` table. We use the presence of this value to indicate in the UI that the device is in the 'Validated' state. Adds this indicator to Rack and Device page, and adds a new tabulation in the Status page.

Fixed a bug where it was not possible to make settings falsy values.