### PR TITLE
Show relays associated with a workspace

### DIFF
--- a/Conch/docs/conch-api/openapi-spec.yaml
+++ b/Conch/docs/conch-api/openapi-spec.yaml
@@ -361,9 +361,17 @@ paths:
                 $ref: "#/components/schemas/Error"
   /workspace/{workspace_id}/relay:
     get:
-      summary: List all Relay devices a user has used in a Workspace
+      summary: List all Relay devices used in a Workspace
       tags: [Relay]
       operationId: getRelays
+      parameter:
+        - in: query
+          name: Active
+          description: >
+            If set to a non-zero integer, return only Relays that are current
+            active
+          schema:
+            type: integer
       responses:
         '200':
           description: List of relay objects

--- a/Conch/lib/Conch/Route/Relay.pm
+++ b/Conch/lib/Conch/Route/Relay.pm
@@ -14,18 +14,16 @@ use Data::Printer;
 
 set serializer => 'JSON';
 
-# Returns all relay devices and their status.
-get '/relay' => needs login => sub {
-  my $user_id = session->read('user_id');
-  my @relays = list_user_relays( schema, $user_id );
-  status_200( \@relays );
-};
-
-# Returns all active relay devices and their status.
-get '/relay/active' => needs login => sub {
-  my $user_id = session->read('user_id');
-  my @relays = list_user_relays( schema, $user_id, 2 );
-  status_200( \@relays );
+get '/workspace/:wid/relay' => needs login => sub {
+  my $ws_id  = param 'wid';
+  my $relays;
+  if (param 'active') {
+    $relays = list_workspace_relays( schema, $ws_id, 2);
+  }
+  else {
+    $relays = list_workspace_relays( schema, $ws_id );
+  }
+  status_200( $relays );
 };
 
 # This acts as both an initial registration and heartbeat endpoint.

--- a/Conch/lib/Conch/Schema/Result/RelayDevices.pm
+++ b/Conch/lib/Conch/Schema/Result/RelayDevices.pm
@@ -18,12 +18,14 @@ __PACKAGE__->result_source_instance->is_virtual(1);
 
 # Takes a relay ID and returns the list of devices connected to that relay
 __PACKAGE__->result_source_instance->view_definition(q[
-  SELECT device.*
+  SELECT device.*, dl.rack_id
   FROM relay r
   INNER JOIN device_relay_connection dr
     ON r.id = dr.relay_id
   INNER JOIN device
     ON dr.device_id = device.id
+  INNER JOIN device_location dl
+    ON dl.device_id = device.id
   WHERE r.id = ?
   ORDER by dr.last_seen desc
 ]);

--- a/Conch/ui/src/models/Relay.js
+++ b/Conch/ui/src/models/Relay.js
@@ -1,5 +1,7 @@
 import m from "mithril";
 
+import Workspace from "./Workspace";
+
 // Use a natural sort with devices that end with a number.
 // e.g, 'PRD10' comes after 'PRD2'
 // Fall back on ID if no alias is set
@@ -23,11 +25,11 @@ const Relay = {
     list: [],
     activeList: [],
     current: null,
-    loadRelays: () => {
+    loadRelays: (workspaceId) => {
         return m
             .request({
                 method: "GET",
-                url: "/relay",
+                url: `/workspace/${workspaceId}/relay`,
                 withCredentials: true,
             })
             .then(res => {
@@ -41,11 +43,11 @@ const Relay = {
                 }
             });
     },
-    loadActiveRelays: () => {
+    loadActiveRelays: (workspaceId) => {
         return m
             .request({
                 method: "GET",
-                url: "/relay/active",
+                url: `/workspace/${workspaceId}/relay?active=1`,
                 withCredentials: true,
             })
             .then(res => {

--- a/Conch/ui/src/views/Rack.js
+++ b/Conch/ui/src/views/Rack.js
@@ -16,7 +16,7 @@ const allRacks = {
         Auth.requireLogin(
             Workspace.withWorkspace(workspaceId => {
                 Promise.all([
-                    Relay.loadActiveRelays(),
+                    Relay.loadActiveRelays(workspaceId),
                     Rack.loadRooms(workspaceId),
                 ]).then(() => (state.loading = false));
             })

--- a/Conch/ui/src/views/Relay/List.js
+++ b/Conch/ui/src/views/Relay/List.js
@@ -1,12 +1,15 @@
 import m from "mithril";
 import t from "i18n4v";
 import Relay from "../../models/Relay";
+import Workspace from "../../models/Workspace";
 
 export default {
     loading: true,
 
     oninit: ({ state }) => {
-        Relay.loadRelays().then(() => (state.loading = false));
+        Workspace.withWorkspace(workspaceId => {
+            Relay.loadRelays(workspaceId).then(() => {state.loading = false});
+        });
     },
 
     view: ({ state, attrs }) => {

--- a/Conch/ui/src/views/Status.js
+++ b/Conch/ui/src/views/Status.js
@@ -39,7 +39,7 @@ export default {
             Workspace.withWorkspace(workspaceId => {
                 Promise.all([
                     Device.loadDevices(workspaceId),
-                    Relay.loadActiveRelays(),
+                    Relay.loadActiveRelays(workspaceId),
                     Rack.loadRooms(workspaceId),
                 ]).then(() => (state.loading = false));
             })


### PR DESCRIPTION
Rework the Relay endpoint to get all relays last associated with racks assigned in the workspace.

A nice by-product of this change is that parent workspaces will always see where Relays are, even if they're being used by a user in a sub-workspace. The Global workspace will show the status of all Relays in the system.