### PR TITLE
When creating the 'conch' user in reset-database.sh, give it LOGIN ability.

### DIFF
--- a/sql/reset-database.sh
+++ b/sql/reset-database.sh
@@ -4,7 +4,7 @@ BASEDIR=$(cd `dirname $0` && pwd)
 
 psql -d postgres -c 'DROP DATABASE conch'
 psql -d postgres -c 'DROP DATABASE conch'
-psql -d postgres -c 'CREATE ROLE conch'
+psql -d postgres -c 'CREATE ROLE conch LOGIN'
 psql -d postgres -c 'CREATE DATABASE conch OWNER conch'
 
 $BASEDIR/load.sh


### PR DESCRIPTION
On macOS, via homebrew, postgres comes with all/all trust but users still need login ability to run 'psql'. Without LOGIN, `make reset-database` fails right away.