### PR TITLE
feat(api): Racks can be assigned to workspace

### DIFF
--- a/Conch/docs/conch-api/openapi-spec.yaml
+++ b/Conch/docs/conch-api/openapi-spec.yaml
@@ -616,10 +616,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  status:
-                    type: string
+                $ref: "#/components/schemas/Error"
         default:
           description: Unexpected error
           content:
@@ -928,14 +925,69 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  workspace/{workspace_id}/rack/:uuid:
+    post:
+      summary: Add a rack to the workspace
+      operationId: addRackToWorkspace
+      description: >
+        Add an existing rack to the workspace. This enables adding a single
+        rack to a workspace without having to add all racks in a the entire
+        datacenter room.  The rack must be a member of the parents workspace to
+        be added.
+      requestBody:
+        required: true
+        description: >
+          Map between device serial numbers and the slot number they should
+          be assigned in the rack
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  format: uuid
+                  description: The Rack ID to be added to the workspace
+      responses:
+        '303':
+          description: >
+            Redirection to the rack resource in the workspace
+          headers:
+            Location:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Location:
+                    type: string
+                    description: URI for rack in the workspace
+        '409':
+          description: >
+            A condition exists that prevents the rack from being assigned.
+            Either the rack is not assigned to the parent workspace, or the
+            rack is already assigned to the workspace via a datacenter room
+            assignment
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  workspace/{workspace_id}/rack/{rack_id}:
     get:
       summary: Get details about a specific rack
       tags: [Rack]
       operationId: getRack
       responses:
         '200':
-          description: Details about a rack, including device assignments in slots
+          description: >
+            Details about a rack, including device assignments in slots
           content:
             application/json:
               schema:
@@ -948,7 +1000,38 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  workspace/{workspace_id}/rack/:uuid/layout:
+    delete:
+      summary: Remove rack from workspace
+      operationId: removeRackFromWorkspace
+      description: >
+        Un-assign the rack from the workspace.  Only removes racks that have
+        been explicitly assigned using `addRackToWorkspace`. Rack assignments
+        that are assigned via a datacenter room assignment will not be
+        modified. This will remove the rack from all child sub-workspaces if
+        the rack has been assigned to those subspaces using
+        `addRackToWorkspace`.
+      responses:
+        '204':
+          description: >
+            The rack assignment has been successfully removed
+        '404':
+          description: >
+            Rack ID not found or is not assigned to the workspace
+        '409':
+          description: >
+            The rack is assigned to the workspace via a datacenter room
+            assignment and cannot be removed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  workspace/{workspace_id}/rack/{rack_id}/layout:
     post:
       summary: Update multiple slots in a given rack
       tags: [Rack]

--- a/Conch/lib/Conch/Control/Rack.pm
+++ b/Conch/lib/Conch/Control/Rack.pm
@@ -13,7 +13,8 @@ our @EXPORT =
 
 sub get_rack {
   my ( $schema, $rack_id ) = @_;
-  my $rack = $schema->resultset('DatacenterRack')->find( { id => $rack_id } );
+  my $rack = $schema->resultset('DatacenterRack')
+    ->find( { id => $rack_id, deactivated => { '=', undef } } );
   return $rack;
 }
 
@@ -34,10 +35,11 @@ sub workspace_racks {
   my @racks = $schema->resultset('WorkspaceRacks')
     ->search( {}, { bind => [$workspace_id] } )->all;
 
+  my @rack_room_ids = map { $_->datacenter_room_id } @racks;
+
   my @datacenter_room =
     $schema->resultset('DatacenterRoom')
-    ->search( { 'workspace_datacenter_rooms.workspace_id' => $workspace_id },
-    { join => 'workspace_datacenter_rooms' } )->all;
+    ->search( { 'id' => { -in => \@rack_room_ids } } )->all;
 
   my @rack_ids = map { $_->id } @racks;
   my $rack_progress = {};

--- a/sql/migrations/0014-workspace-rack.sql
+++ b/sql/migrations/0014-workspace-rack.sql
@@ -1,0 +1,12 @@
+SELECT run_migration(14, $$
+
+
+    -- Workspaces can contain individual racks in addition to whole datacenter rooms
+    CREATE TABLE workspace_datacenter_rack (
+        workspace_id       UUID REFERENCES workspace(id),
+        datacenter_rack_id UUID REFERENCES datacenter_rack(id),
+        UNIQUE (workspace_id, datacenter_rack_id)
+    );
+
+$$);
+


### PR DESCRIPTION
Individual racks can be assigned and unassigned from a workspace. This means you can create a workspace with a subset of the racks in a datacenter room rather than all of them. 

To add a rack to a workspace:
```
http POST ':5001/workspace/6252cb76-006c-496f-8694-08e1598c1783/rack' --session dev_session --follow <<EOF
{ "id" : "5f7b5789-eaed-48a3-970d-af29fb6edad0" }
EOF
```
(_Note_: This endpoint returns `304` with a Location header, so you can use `--follow` with Httpie to get the full resource after assigning it)

To remove a rack from a workspace:
```
http DELETE ':5001/workspace/6252cb76-006c-496f-8694-08e1598c1783/rack/8852d6e9-823a-4488-96f3-b6980bd1410f' --session dev_session 
```

Important caveats:

* Only racks that are assigned to the parent workspace can be assigned. For any sub-workspace of the GLOBAL workspace, this won't be an issue as it contains all datacenter rooms and racks
* Removing a rack removes it from all children
* You cannot remove a rack that is assigned implicitly via datacenter room assignment (it will return `409 Conflict`)
* Adding a rack if it's room is assigned will return `409 Conflict` and describe the condition rather than having an effect.