### PR TITLE
feat(api,ui): Add asset tag field to device

### DIFF
--- a/Conch/docs/conch-api/openapi-spec.yaml
+++ b/Conch/docs/conch-api/openapi-spec.yaml
@@ -712,6 +712,48 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /device/{serial}/asset_tag:
+    post:
+      tags: [Device]
+      summary: Set the asset tag for a device
+      operationId: setDeviceAssetTag
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                asset_tag:
+                  type: string
+      responses:
+        '303':
+          description: >
+            Redirection to the updated device resource
+          headers:
+            Location:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Location:
+                    type: string
+                    description: URI for updated device
+        '400':
+          description: >
+            JSON Object with key `"asset_tag"` and string value required in request body.
+        '404':
+          description: >
+            Device with specified ID not found or user doesn't have access
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /device/{serial}/location:
     get:
       tags: [Device]

--- a/Conch/lib/Conch/Control/Device.pm
+++ b/Conch/lib/Conch/Control/Device.pm
@@ -18,6 +18,7 @@ our @EXPORT = qw(
   graduate_device triton_reboot_device set_triton_uuid update_device_location
   delete_device_location get_validation_criteria get_active_devices
   get_devices_by_health unlocated_devices device_response mark_device_validated
+  set_device_asset_tag 
 );
 
 sub get_validation_criteria {
@@ -346,6 +347,14 @@ sub mark_device_validated {
   my ( $schema, $device ) = @_;
   $schema->resultset('Device')->find( { id => $device->id } )
     ->update( { validated => \'NOW()', updated => \'NOW()' } );
+  return 1;
+}
+
+sub set_device_asset_tag {
+  my ( $schema, $device_id, $asset_tag ) = @_;
+
+  $schema->resultset('Device')->find( { id => $device_id } )
+    ->update( { asset_tag => $asset_tag, updated => \'NOW()' } );
   return 1;
 }
 

--- a/Conch/lib/Conch/Route/Device.pm
+++ b/Conch/lib/Conch/Route/Device.pm
@@ -448,11 +448,29 @@ post '/device/:serial/triton_uuid' => needs login => sub {
   my $device = lookup_device_for_user( schema, $serial, $user_id );
   return status_404("Device $serial not found") unless $device;
 
-  my $triton_uuid = param 'triton_uuid';
+  my $triton_uuid = body_parameters->get('triton_uuid');
   return status_400("'triton_uuid' must be present and a UUID")
     unless defined($triton_uuid) && is_uuid($triton_uuid);
 
   set_triton_uuid( schema, $device->id, $triton_uuid );
+
+  my %location = ( Location => root_uri_for "/device/$serial" );
+  response_header(%location);
+  return status_303( \%location );
+};
+
+post '/device/:serial/asset_tag' => needs login => sub {
+  my $user_id = session->read('user_id');
+  my $serial  = param 'serial';
+
+  my $device = lookup_device_for_user( schema, $serial, $user_id );
+  return status_404("Device $serial not found") unless $device;
+
+  my $asset_tag = body_parameters->get('asset_tag');
+  return status_400("'asset_tag' must be present and a string value")
+    unless defined($asset_tag) && ref($asset_tag) eq '';
+
+  set_device_asset_tag( schema, $device->id, $asset_tag );
 
   my %location = ( Location => root_uri_for "/device/$serial" );
   response_header(%location);

--- a/Conch/lib/Conch/Schema/Result/DatacenterRack.pm
+++ b/Conch/lib/Conch/Schema/Result/DatacenterRack.pm
@@ -193,9 +193,24 @@ __PACKAGE__->belongs_to(
   { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
 );
 
+=head2 workspace_datacenter_racks
 
-# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-11-29 17:37:40
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:7R7kakhG+2n2zIw2ZkC3iQ
+Type: has_many
+
+Related object: L<Conch::Schema::Result::WorkspaceDatacenterRack>
+
+=cut
+
+__PACKAGE__->has_many(
+  "workspace_datacenter_racks",
+  "Conch::Schema::Result::WorkspaceDatacenterRack",
+  { "foreign.datacenter_rack_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-12-06 09:14:41
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:xhB151+ZCi/1OtV981sQig
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/Conch/lib/Conch/Schema/Result/Device.pm
+++ b/Conch/lib/Conch/Schema/Result/Device.pm
@@ -123,6 +123,11 @@ __PACKAGE__->table("device");
   is_nullable: 1
   size: 16
 
+=head2 asset_tag
+
+  data_type: 'text'
+  is_nullable: 1
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -166,6 +171,8 @@ __PACKAGE__->add_columns(
   { data_type => "timestamp with time zone", is_nullable => 1 },
   "triton_uuid",
   { data_type => "uuid", is_nullable => 1, size => 16 },
+  "asset_tag",
+  { data_type => "text", is_nullable => 1 },
 );
 
 =head1 PRIMARY KEY
@@ -377,8 +384,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-11-29 17:37:40
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:mkeqNs/X+IM/teyzkv+hZg
+# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-12-06 09:14:41
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:4iHvTsEb0oqOxEBNL99zhw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/Conch/lib/Conch/Schema/Result/Workspace.pm
+++ b/Conch/lib/Conch/Schema/Result/Workspace.pm
@@ -145,6 +145,21 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+=head2 workspace_datacenter_racks
+
+Type: has_many
+
+Related object: L<Conch::Schema::Result::WorkspaceDatacenterRack>
+
+=cut
+
+__PACKAGE__->has_many(
+  "workspace_datacenter_racks",
+  "Conch::Schema::Result::WorkspaceDatacenterRack",
+  { "foreign.workspace_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
 =head2 workspace_datacenter_rooms
 
 Type: has_many
@@ -176,8 +191,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-10-23 16:37:39
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:zPfIlerNBuWdVu7jKImfmQ
+# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-12-06 09:14:41
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:uQQS5FlCm40UfKm6qi3nVw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/Conch/lib/Conch/Schema/Result/WorkspaceDatacenterRack.pm
+++ b/Conch/lib/Conch/Schema/Result/WorkspaceDatacenterRack.pm
@@ -1,0 +1,134 @@
+use utf8;
+package Conch::Schema::Result::WorkspaceDatacenterRack;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+Conch::Schema::Result::WorkspaceDatacenterRack
+
+=cut
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=item * L<DBIx::Class::TimeStamp>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp");
+
+=head1 TABLE: C<workspace_datacenter_rack>
+
+=cut
+
+__PACKAGE__->table("workspace_datacenter_rack");
+
+=head1 ACCESSORS
+
+=head2 workspace_id
+
+  data_type: 'uuid'
+  is_foreign_key: 1
+  is_nullable: 1
+  size: 16
+
+=head2 datacenter_rack_id
+
+  data_type: 'uuid'
+  is_foreign_key: 1
+  is_nullable: 1
+  size: 16
+
+=cut
+
+__PACKAGE__->add_columns(
+  "workspace_id",
+  { data_type => "uuid", is_foreign_key => 1, is_nullable => 1, size => 16 },
+  "datacenter_rack_id",
+  { data_type => "uuid", is_foreign_key => 1, is_nullable => 1, size => 16 },
+);
+
+=head1 UNIQUE CONSTRAINTS
+
+=head2 C<workspace_datacenter_rack_workspace_id_datacenter_rack_id_key>
+
+=over 4
+
+=item * L</workspace_id>
+
+=item * L</datacenter_rack_id>
+
+=back
+
+=cut
+
+__PACKAGE__->add_unique_constraint(
+  "workspace_datacenter_rack_workspace_id_datacenter_rack_id_key",
+  ["workspace_id", "datacenter_rack_id"],
+);
+
+=head1 RELATIONS
+
+=head2 datacenter_rack
+
+Type: belongs_to
+
+Related object: L<Conch::Schema::Result::DatacenterRack>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "datacenter_rack",
+  "Conch::Schema::Result::DatacenterRack",
+  { id => "datacenter_rack_id" },
+  {
+    is_deferrable => 0,
+    join_type     => "LEFT",
+    on_delete     => "NO ACTION",
+    on_update     => "NO ACTION",
+  },
+);
+
+=head2 workspace
+
+Type: belongs_to
+
+Related object: L<Conch::Schema::Result::Workspace>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "workspace",
+  "Conch::Schema::Result::Workspace",
+  { id => "workspace_id" },
+  {
+    is_deferrable => 0,
+    join_type     => "LEFT",
+    on_delete     => "NO ACTION",
+    on_update     => "NO ACTION",
+  },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-12-06 09:14:41
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ZbnT6SovkDj1+/iJLEDhCg
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+__PACKAGE__->meta->make_immutable;
+1;

--- a/Conch/ui/src/models/Device.js
+++ b/Conch/ui/src/models/Device.js
@@ -159,6 +159,15 @@ const Device = {
         }
         return false;
     },
+
+    setAssetTag(deviceId, assetTag) {
+        return m.request({
+            method: "POST",
+            url: `/device/${deviceId}/asset_tag`,
+            data: { asset_tag: assetTag },
+            withCredentials: true,
+        });
+    },
 };
 
 export default Device;

--- a/Conch/ui/src/views/Device.js
+++ b/Conch/ui/src/views/Device.js
@@ -7,7 +7,7 @@ import Table from "./component/Table";
 import Icons from "./component/Icons";
 
 const allDevices = {
-    oninit({attrs}) {
+    oninit({ attrs }) {
         Auth.requireLogin(
             Workspace.withWorkspace(workspaceId => {
                 Device.loadDeviceIds(workspaceId);
@@ -15,21 +15,23 @@ const allDevices = {
         );
     },
     view(vnode) {
-        return Device.deviceIds.map(deviceId => m(
-            "a.selection-list-item",
-            {
-                href: `/device/${deviceId}`,
-                onclick() {
-                    loadDeviceDetails(deviceId);
+        return Device.deviceIds.map(deviceId =>
+            m(
+                "a.selection-list-item",
+                {
+                    href: `/device/${deviceId}`,
+                    onclick() {
+                        loadDeviceDetails(deviceId);
+                    },
+                    oncreate: m.route.link,
+                    class:
+                        Device.current && deviceId === Device.current.id
+                            ? "selection-list-item-active"
+                            : "",
                 },
-                oncreate: m.route.link,
-                class:
-                    Device.current && deviceId === Device.current.id
-                        ? "selection-list-item-active"
-                        : "",
-            },
-            deviceId
-        ));
+                deviceId
+            )
+        );
     },
 };
 
@@ -51,7 +53,7 @@ function loadDeviceDetails(id) {
 }
 
 const deviceReport = {
-    oninit({attrs}) {
+    oninit({ attrs }) {
         loadDeviceDetails(attrs.id);
     },
     view(vnode) {
@@ -247,34 +249,39 @@ const deviceReport = {
             [t("Status"), t("Type"), t("Name"), t("Metric"), t("Log")],
             Device.current.validations
                 .sort((a, b) => {
-                    if (a.component_type < b.component_type)
+                    if (
+                        a.component_type + a.component_name <
+                        b.component_type + b.component_name
+                    )
                         return -1;
-                    if (a.component_type > b.component_type)
+                    if (
+                        a.component_type + a.component_name >
+                        b.component_type + b.component_name
+                    )
                         return 1;
-                    if (a.component_name < b.component_name)
-                        return -1;
-                    if (a.component_name > b.component_name)
-                        return 1;
+
                     return 0;
                 })
                 .map(v => [
-                v.status ? m('i') : Icons.warning,
-                v.component_type,
-                v.component_name,
-                v.metric,
-                v.log,
-            ])
+                    v.status ? m("i") : Icons.warning,
+                    v.component_type,
+                    v.component_name,
+                    v.metric,
+                    v.log,
+                ])
         );
         const logs = Table(
             t("Devices Logs (20 most recent)"),
             [t("Component Type"), t("Component ID"), t("Time"), t("Log")],
-            Device.logs.map(({component_type, component_id, created, msg}) => [
-                component_type,
-                component_id,
-                created,
-                // pre requried to preserve multi-lines
-                m("span.log-text", msg),
-            ])
+            Device.logs.map(
+                ({ component_type, component_id, created, msg }) => [
+                    component_type,
+                    component_id,
+                    created,
+                    // pre requried to preserve multi-lines
+                    m("span.log-text", msg),
+                ]
+            )
         );
         return m(".pure-g", [
             firmwareUpdatingNotification,

--- a/sql/migrations/0014-workspace-rack.sql
+++ b/sql/migrations/0014-workspace-rack.sql
@@ -1,6 +1,5 @@
 SELECT run_migration(14, $$
 
-
     -- Workspaces can contain individual racks in addition to whole datacenter rooms
     CREATE TABLE workspace_datacenter_rack (
         workspace_id       UUID REFERENCES workspace(id),
@@ -9,4 +8,3 @@ SELECT run_migration(14, $$
     );
 
 $$);
-

--- a/sql/migrations/0015-device-asset-tag.sql
+++ b/sql/migrations/0015-device-asset-tag.sql
@@ -1,0 +1,7 @@
+SELECT run_migration(15, $$
+
+    -- Add asset tag column
+    ALTER TABLE device ADD COLUMN asset_tag text;
+
+$$);
+


### PR DESCRIPTION
Add asset tag field to device and allow users to assign a device asset tag on the Rack view page.
<img width="1174" alt="screen shot 2017-12-06 at 9 31 00 am" src="https://user-images.githubusercontent.com/5587177/33672744-38f76872-da68-11e7-9f8f-776f354b8c8f.png">

Adds endpoint `POST /device/:id/asset_tag` for setting the asset tag. Documented in OpenAPI spec.