### PR TITLE
Add new HAv2 server, add hardware_product migration

### DIFF
--- a/sql/hardware.sql
+++ b/sql/hardware.sql
@@ -12,6 +12,8 @@ INSERT INTO hardware_product (name, alias, prefix, vendor)
 INSERT INTO hardware_product (name, alias, prefix, vendor)
        VALUES ( 'Joyent-Compute-Platform-3301', 'Hallasan A', 'HA', ( SELECT id FROM hardware_vendor WHERE name = 'Dell' ) );
 INSERT INTO hardware_product (name, alias, prefix, vendor)
+       VALUES ( 'Joyent-Compute-Platform-3101', 'Hallasan A r2', 'HA', ( SELECT id FROM hardware_vendor WHERE name = 'SuperMicro' ) );
+INSERT INTO hardware_product (name, alias, prefix, vendor)
        VALUES ( 'Joyent-Compute-Platform-3302', 'Hallasan C', 'HC', ( SELECT id FROM hardware_vendor WHERE name = 'Dell' ) );
 INSERT INTO hardware_product (name, alias, prefix, vendor)
        VALUES ( 'CERES', 'Type 1', 'CE', ( SELECT id FROM hardware_vendor WHERE name = 'Dell' ) );

--- a/sql/hardware_profiles.sql
+++ b/sql/hardware_profiles.sql
@@ -36,6 +36,16 @@ INSERT INTO hardware_product_profile ( product_id, purpose, bios_firmware, cpu_n
        );
 
 INSERT INTO hardware_product_profile ( product_id, purpose, bios_firmware, cpu_num, cpu_type,
+            dimms_num, ram_total, nics_num, sas_num, sas_size, ssd_num, ssd_size, ssd_slots, psu_total, zpool_id,
+            rack_unit )
+      VALUES (  ( SELECT id FROM hardware_product WHERE name = 'Joyent-Compute-Platform-3101' ),
+            'General Compute', '2.0a', 2, 'Intel(R) Xeon(R) CPU E5-2690 v4 @ 2.60GHz',
+            16, 512, 7, 15, 1117.81, 1, 93.16, '0', 2,
+            ( SELECT id FROM zpool_profile WHERE name = 'Joyent-Compute-Platform-3101' ),
+            2
+       );
+
+INSERT INTO hardware_product_profile ( product_id, purpose, bios_firmware, cpu_num, cpu_type,
             dimms_num, ram_total, nics_num, sas_num, ssd_num, ssd_size, ssd_slots, psu_total, zpool_id,
             rack_unit )
       VALUES (  ( SELECT id FROM hardware_product WHERE name = 'Joyent-Compute-Platform-3302' ),

--- a/sql/migrations/0016-drop-hw-prefix-unique.sql
+++ b/sql/migrations/0016-drop-hw-prefix-unique.sql
@@ -1,0 +1,7 @@
+SELECT run_migration(16, $$
+
+    -- Remove the UNIQUE constraint on the hardware_product.prefix field
+    ALTER TABLE hardware_product DROP constraint hardware_product_prefix_key;
+
+$$);
+

--- a/sql/zpool_profiles.sql
+++ b/sql/zpool_profiles.sql
@@ -2,6 +2,9 @@ INSERT INTO zpool_profile (name, vdev_t, vdev_n, disk_per, spare, log, cache)
        VALUES ( 'Joyent-Compute-Platform-3301', 'mirror', 7, 2, 1, 1, 0 );
 
 INSERT INTO zpool_profile (name, vdev_t, vdev_n, disk_per, spare, log, cache)
+       VALUES ( 'Joyent-Compute-Platform-3101', 'mirror', 7, 2, 1, 1, 0 );
+
+INSERT INTO zpool_profile (name, vdev_t, vdev_n, disk_per, spare, log, cache)
        VALUES ( 'Joyent-Compute-Platform-3302', 'raidz2', 1, 8, 0, 0, 0 );
 
 INSERT INTO zpool_profile (name, vdev_t, vdev_n, disk_per, spare, log, cache)


### PR DESCRIPTION
* Adds new HAv2 server (SMCI version of HA)
* Drops UNIQUE constraint on `hardware_product.prefix`