### PR TITLE
feat(api): Add GET /hardware_product and GET /hardware_product/:id

### DIFF
--- a/Conch/docs/conch-api/openapi-spec.yaml
+++ b/Conch/docs/conch-api/openapi-spec.yaml
@@ -36,6 +36,7 @@ tags:
       through a Relay device.
   - name: Relay
   - name: Rack
+  - name: Hardware Product
 paths:
   /login:
     post:
@@ -955,6 +956,45 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /hardware_product:
+    get:
+      tags: [Hardware Product]
+      summary: List all available hardware products
+      operationId: getHardwareProducts
+      responses:
+        '200':
+          description: >
+            List of hardware products with profiles
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/HardwareProduct"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /hardware_product/{hardware_product_id}:
+    get:
+      tags: [Hardware Product]
+      summary: Get a hardware product specified by ID
+      operationId: getHardwareProduct
+      responses:
+        '200':
+          description: Hardware product with profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HardwareProduct"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /workspace/{workspace_id}/rack:
     get:
       summary: List all available racks in a workspace
@@ -1031,7 +1071,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  workspace/{workspace_id}/rack/{rack_id}:
+  /workspace/{workspace_id}/rack/{rack_id}:
     get:
       summary: Get details about a specific rack
       tags: [Rack]
@@ -1083,7 +1123,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  workspace/{workspace_id}/rack/{rack_id}/layout:
+  /workspace/{workspace_id}/rack/{rack_id}/layout:
     post:
       summary: Update multiple slots in a given rack
       tags: [Rack]
@@ -1123,7 +1163,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  workspace/{workspace_id}/problem:
+  /workspace/{workspace_id}/problem:
     get:
       tags: [Device]
       summary: Describe all components failing validation in a workspace
@@ -1152,31 +1192,6 @@ components:
       type: object
       properties:
         error:
-          type: string
-    Relay:
-      type: object
-      properties:
-        alias:
-          type: string
-        created:
-          type: string
-          format: date-time
-        devices:
-          description: >
-            Array of devices that have reported through this relay device
-          type: array
-          items:
-            $ref: "#/components/schemas/Device"
-        id:
-          type: string
-        ipaddr:
-          type: string
-        ssh_port:
-          type: string
-        updated:
-          type: string
-          format: date-time
-        version:
           type: string
     DetailedDevice:
       type: object
@@ -1381,6 +1396,77 @@ components:
             alias:
               type: string
               description: Hardware product alias
+    HardwareProduct:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        alias:
+          type: string
+        prefix:
+          type: string
+        vendor:
+          type: string
+        profile:
+          type: object
+          properties:
+            bios_firmware:
+              type: string
+            cpu_num:
+              type: integer
+            cpu_type:
+              type: string
+            dimms_num:
+              type: integer
+            hba_firmware:
+              nullable: true
+              type: string
+            nics_num:
+              type: integer
+            psu_total:
+              type: integer
+            purpose:
+              type: string
+            ram_total:
+              type: integer
+            sas_num:
+              type: integer
+            sas_size:
+              type: integer
+            sas_slots:
+              type: string
+            sata_num:
+              type: integer
+            sata_size:
+              type: integer
+            sata_slots:
+              type: string
+            ssd_num:
+              type: integer
+            ssd_size:
+              type: integer
+            ssd_slots:
+              type: string
+            zpool:
+              type: object
+              properties:
+                cache:
+                  type: integer
+                log:
+                  type: integer
+                disks_per:
+                  nullable: true
+                  type: integer
+                spare:
+                  type: integer
+                vdev_n:
+                  type: integer
+                vdev_t:
+                  type: string
+
     RackSummary:
       type: object
       properties:
@@ -1436,6 +1522,31 @@ components:
                 nullable: true
                 description: Device assigned to this slot or null
                 $ref: "#/components/schemas/Device"
+    Relay:
+      type: object
+      properties:
+        alias:
+          type: string
+        created:
+          type: string
+          format: date-time
+        devices:
+          description: >
+            Array of devices that have reported through this relay device
+          type: array
+          items:
+            $ref: "#/components/schemas/Device"
+        id:
+          type: string
+        ipaddr:
+          type: string
+        ssh_port:
+          type: string
+        updated:
+          type: string
+          format: date-time
+        version:
+          type: string
     Problems:
       type: object
       properties:

--- a/Conch/lib/Conch.pm
+++ b/Conch/lib/Conch.pm
@@ -2,10 +2,11 @@ package Conch;
 use Dancer2;
 use Conch::Route::User;
 use Conch::Route::Device;
+use Conch::Route::Feedback;
+use Conch::Route::HardwareProduct;
+use Conch::Route::Problem;
 use Conch::Route::Rack;
 use Conch::Route::Relay;
-use Conch::Route::Problem;
-use Conch::Route::Feedback;
 use Conch::Route::Workspace;
 
 our $VERSION = '2.0';

--- a/Conch/lib/Conch/Control/HardwareProduct.pm
+++ b/Conch/lib/Conch/Control/HardwareProduct.pm
@@ -1,0 +1,73 @@
+package Conch::Control::HardwareProduct;
+
+use strict;
+use warnings;
+use Log::Any '$log';
+
+use Data::Printer;
+
+use Exporter 'import';
+our @EXPORT = qw( list_hardware_products get_hardware_product );
+
+sub list_hardware_products {
+  my ($schema) = @_;
+
+  my @hardware_products = $schema->resultset('HardwareProduct')->search(
+    {
+      'me.deactivated' => { '=', undef },
+      'hardware_product_profile.id' => { '!=', undef }
+    },
+    { prefetch => { hardware_product_profile => 'zpool' } }
+  )->all;
+
+  my @hw_response = map { build_hardware_product_hash($_) } @hardware_products;
+  return @hw_response;
+}
+
+sub get_hardware_product {
+  my ( $schema, $hw_id ) = @_;
+
+  my $hardware_product = $schema->resultset('HardwareProduct')->search(
+    {
+      'me.id'          => $hw_id,
+      'me.deactivated' => { '=', undef },
+      'hardware_product_profile.id' => { '!=', undef }
+    },
+    { prefetch => { hardware_product_profile => 'zpool' } }
+  )->single;
+
+  return build_hardware_product_hash($hardware_product) if defined($hardware_product);
+}
+
+# Build a hash with hardware product and hardware product profile details.
+# Includes zpool info if available. Expects hardware_product_profile to exist
+sub build_hardware_product_hash {
+  my ($hw) = shift;
+
+  my $hw_profile = $hw->hardware_product_profile;
+
+  my %hw_columns = $hw->get_columns;
+
+  my %profile_columns = $hw_profile->get_columns;
+
+  my %res     = %hw_columns{qw/id name alias prefix /};
+  my %profile = %profile_columns{
+    qw/purpose bios_firmware hba_firmware
+      cpu_num cpu_type dimms_num ram_total nics_num sata_num sata_size sata_slots
+      sas_num sas_size sas_slots ssd_num ssd_size ssd_slots psu_total/
+  };
+  $res{profile} = \%profile;
+
+  my $zpool_profile = $hw_profile->zpool;
+  if ( defined($zpool_profile) ) {
+    my %zpool_columns = $zpool_profile->get_columns;
+    my %zpool = %zpool_columns{qw/vdev_t vdev_n disks_per spare log cache/};
+    $res{profile}{zpool} = \%zpool;
+  }
+  else {
+    $res{profile}{zpool} = undef;
+  }
+  return \%res;
+}
+
+1;

--- a/Conch/lib/Conch/Route/HardwareProduct.pm
+++ b/Conch/lib/Conch/Route/HardwareProduct.pm
@@ -1,0 +1,37 @@
+package Conch::Route::HardwareProduct;
+
+use strict;
+use warnings;
+
+use Dancer2 appname => 'Conch';
+use Dancer2::Plugin::Auth::Tiny;
+use Dancer2::Plugin::DBIC;
+use Dancer2::Plugin::REST;
+use Hash::MultiValue;
+
+use Conch::Control::HardwareProduct;
+
+use Data::Printer;
+use Data::Validate::UUID 'is_uuid';
+
+set serializer => 'JSON';
+
+
+get '/hardware_product' => needs login => sub {
+  my @hardware_products = list_hardware_products(schema);
+  status_200(\@hardware_products);
+};
+
+get '/hardware_product/:id' => needs login => sub {
+  my $hw_id     = param 'id';
+  return status_400("Hardware Product ID in path must be a UUID") unless is_uuid($hw_id);
+
+  my $hardware_product = get_hardware_product(schema, $hw_id);
+
+  return status_404("Hardware Product '$hw_id' not found") unless $hardware_product;
+
+  status_200($hardware_product);
+};
+
+
+1;


### PR DESCRIPTION
Phil needs access to hardare product information to complete the build
out of northeast-1a. This adds two endpoints to API:

1. list all hardware products defined **that has an associated hardware
product profile** (context:
https://chat.joyent.us/joyent/pl/1m6osos1s3gctgc4ts65x518ra)
2. get a single hardware product by ID. It also must have hardware
product profile.

Each of these include details from the hardware product profile and
zpool profile (if defined) in the response. All responses specified in
OpenAPI spec.