### PR TITLE
feat(api) Add datacenter vendor name to getDevice location

### DIFF
--- a/Conch/lib/Conch/Control/Device.pm
+++ b/Conch/lib/Conch/Control/Device.pm
@@ -195,8 +195,9 @@ sub device_rack_location {
     $location->{target_hardware_product}{name}  = $target_hardware->name;
     $location->{target_hardware_product}{alias} = $target_hardware->alias;
 
-    $location->{datacenter}{id}   = $datacenter->id;
-    $location->{datacenter}{name} = $datacenter->az;
+    $location->{datacenter}{id}          = $datacenter->id;
+    $location->{datacenter}{name}        = $datacenter->az;
+    $location->{datacenter}{vendor_name} = $datacenter->vendor_name;
   }
 
   return $location;


### PR DESCRIPTION
PhilS requested that we include the vendor_name field in device
location, as we use that name in both the DCIM and Triton's CN rack
traits. The latter are used for affinity hints, so need to be in the
common format.