### PR TITLE
feat(report): Add report dir, time to remediation report

### DIFF
--- a/report/Makefile
+++ b/report/Makefile
@@ -1,0 +1,5 @@
+PHONY: deps
+
+
+deps:
+	@carton install --deployment

--- a/report/README.md
+++ b/report/README.md
@@ -1,0 +1,56 @@
+# Conch Report
+
+This directory contains utilities to dump and process data from the Conch
+databases, scripts to assist with creating Manta jobs, and files to run Manta
+jobs on the raw data.
+
+
+# Overview
+
+## `/bin`
+
+* `device_validation_result_dump.pl` -- perl script to dump all validation
+  results from the database into a directory of files split by day (UTC). See
+  `bin/device-validation-result-dump.pl --help` for command-line options and
+  more details
+
+* `upload_dir_to_manta.sh` -- script to upload a directory to manta. Given a
+  path to a directory as the first argument, it creates a GZIPed tarball and
+  uploads it to Manta. It then creates a Manta job to decompress and un-tar the
+  file into a directory in ~~/stor`. Requies Manta envirnoment variables to be
+  set.
+
+* `start_manta_job.sh` -- script to start a Manta job. Given a path to a local
+  directory with a `job.json` file ("job directory") and a Manta path to the
+  input files as argument, uploads the job directory to Manta and starts a
+  Manta job as defined by the `job.json` file. Requires Manta envirnoment
+  variables to be set.
+
+
+## `manta_job`
+
+This directory contains sub-directories ("job directories") which each define
+and support a Manta job. Each job directory should contain a `job.json` file to
+define the phases and assets for Manta job. The job directory can contain
+scripts and supporting files to be used in the Manta job. The entire directory
+will be uploaded to Manta, and assets can be used in a Manta phase with the
+`"assets"` property in `job.json`.
+
+
+* `time_to_earliest_remediation` -- processes the output of
+  `device_validation_result_dump.pl`. For each device component that resulted
+  in a validation failure, it finds the earliest failure and the earliest
+  remediation of that failure. The JSON output is structured as follows:
+
+  ```
+  {
+    "<device id>" : {
+        "<component_name>": {
+            "first_fail": <validation_result_object>,
+            "first_pass": <validation_result_object | null>
+        },
+        ...
+    },
+    ...
+  }
+  ```

--- a/report/bin/device_validation_result_dump.pl
+++ b/report/bin/device_validation_result_dump.pl
@@ -1,0 +1,125 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use autodie qw{ open close };
+use v5.20;
+
+use DBI;
+use Data::Printer;
+use DateTime::Format::Pg;
+use IO::File;
+use Getopt::Long;
+use Pod::Usage;
+
+
+my $output_dir = "validation_results";
+my $start_date;
+my $end_date;
+
+my $database = 'conch';
+my $user = 'conch';
+my $password = '';
+
+my $help;
+
+GetOptions(
+  "out_dir=s"  => \$output_dir,
+  "start_date=s" => \$start_date,
+  "end_date=s"   => \$end_date,
+  "user|u=s" => \$user,
+  "database|d=s" => \$database,
+  "password|p=s" => \$password,
+  "help|h" => \$help
+) or pod2usage(-verbose => 99);
+
+pod2usage(-verbose => 99) if $help;
+
+
+my $pg_time_parser = DateTime::Format::Pg->new();
+
+my $dbh = DBI->connect("dbi:Pg:dbname=$database", $user, $password);
+
+$dbh or die "cannot connect to Postgres. Make sure env variables PGDATABASE, PGUSER, and any other required are set";
+
+my $sth;
+
+my $date_clause = '';
+if ($start_date || $end_date) {
+  $date_clause = "WHERE ";
+  $date_clause .= "created >= date '$start_date' " if $start_date;
+  $date_clause .= "AND " if $start_date && $end_date;
+  $date_clause .= "created <= date '$end_date'" if $end_date;
+}
+
+$sth = $dbh->prepare(qq{
+  select created from device_validate order by created desc limit 10;
+  SELECT distinct date_trunc('day', created AT TIME ZONE 'UTC')::date as day
+  FROM device_validate
+  $date_clause
+  ORDER by day ASC;
+});
+$sth->execute();
+my $days = $sth->fetchall_arrayref;
+$sth->finish;
+
+$sth = $dbh->prepare(q{
+  SELECT json_build_object(
+    'device_id', device_id,
+    'created', created AT TIME ZONE 'UTC',
+    'validation_result', validation
+  ) from device_validate
+  WHERE created AT TIME ZONE 'UTC' > ($1::date)
+    AND created AT TIME ZONE 'UTC' < ($1::date + interval '1 day') 
+  order by created ASC
+},  { pg_server_prepare => 1 });
+
+
+mkdir $output_dir;
+
+for my $row (@{$days}) {
+  my $day = $row->[0];
+  say "Processing $day...";
+  $sth->bind_param(1, $day);
+  $sth->execute();
+  my $results = $sth->fetchall_arrayref;
+  open(my $fh, ">" , "$output_dir/$day.json.log");
+  print $fh  join("\n", map { $_->[0] } @{$results});
+  close $fh;
+  say "Done";
+}
+
+$dbh->disconnect;
+
+
+__END__
+
+=head1 NAME
+
+device-validation-result-dump - Dump device validation results from Conch DB
+
+=head1 SYNOPSIS
+
+device-validation-result-dump [options]
+
+  Options:
+
+   --out_dir                   directory dumped files will be written. Will be created
+   --start_date=<YYYY-MM-DD>   date to start the dump, inclusive
+   --end_date=<YYYY-MM-DD>     date to end the dump, inclusive
+   --database, d=<DB name>     Conch database name
+   --user, u=<DB username>     database username
+   --password, p=<DB password> database password
+   --help, h                   this help message
+
+B<device-validation-result-dump> will dump all of the validations results into
+files split by day (UTC) the valition result was recorded. The validation
+results 1 per in line in ascending timestamp order (earliest first) and
+formated as JSON with the following schema:
+
+  {
+    "device_id": <device id>,
+    "created": <timestamp>,
+    "validation_result": <validation object>
+  }
+
+=cut

--- a/report/bin/start_manta_job.sh
+++ b/report/bin/start_manta_job.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+test $MANTA_USER || (echo '$MANTA_USER must be defined' && exit 1);
+test $1 || (echo 'First argument must be local directory for manta job' && exit 1);
+test $2 || (echo 'Second argument must be Manta path for job inputs' && exit 1);
+
+manta_job_dir=$1
+job_name=$(basename $manta_job_dir)
+
+test -f $manta_job_dir/job.json || (echo "$manta_job_dir must have job.json file" && exit 1)
+
+manta_input_dir=$2
+
+echo 'Uploading job files...'
+muntar -f <(tar -cf - $manta_job_dir) ~~/stor/job
+echo 'Done.'
+
+echo 'Starting Manta job'
+mfind $manta_input_dir | mjob create -f <(perl -pe 's/\$([_A-Z]+)/$ENV{$1}/g' $manta_job_dir/job.json) -n "$job_name"

--- a/report/bin/upload_dir_to_manta.sh
+++ b/report/bin/upload_dir_to_manta.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+test $1 || (echo 'Must specify local directory to upload' && exit 1)
+
+dir=$1;
+name=$(basename $dir);
+test -d $dir || (echo "Directory '$dir' does not exist" && exit 1);
+
+tar -czf - $dir | mput "~~/stor/$name.tar.gz"
+
+echo "~~/stor/$name.tar.gz" | mjob create -o -m gzcat -m 'muntar -f $MANTA_INPUT_FILE ~~/stor/'

--- a/report/cpanfile
+++ b/report/cpanfile
@@ -1,0 +1,3 @@
+requires 'DBD::Pg';
+requires 'Data::Printer';
+requires 'DateTime::Format::Pg';

--- a/report/cpanfile.snapshot
+++ b/report/cpanfile.snapshot
@@ -1,0 +1,1250 @@
+# carton snapshot format: version 1.0
+DISTRIBUTIONS
+  B-Hooks-EndOfScope-0.21
+    pathname: E/ET/ETHER/B-Hooks-EndOfScope-0.21.tar.gz
+    provides:
+      B::Hooks::EndOfScope 0.21
+      B::Hooks::EndOfScope::PP 0.21
+      B::Hooks::EndOfScope::XS 0.21
+    requirements:
+      ExtUtils::MakeMaker 0
+      Module::Implementation 0.05
+      Sub::Exporter::Progressive 0.001006
+      Text::ParseWords 0
+      Variable::Magic 0.48
+      perl 5.008001
+      strict 0
+      warnings 0
+  Class-Data-Inheritable-0.08
+    pathname: T/TM/TMTM/Class-Data-Inheritable-0.08.tar.gz
+    provides:
+      Class::Data::Inheritable 0.08
+    requirements:
+      ExtUtils::MakeMaker 0
+  Class-Factory-Util-1.7
+    pathname: D/DR/DROLSKY/Class-Factory-Util-1.7.tar.gz
+    provides:
+      Class::Factory::Util 1.7
+    requirements:
+  Class-Inspector-1.32
+    pathname: P/PL/PLICEASE/Class-Inspector-1.32.tar.gz
+    provides:
+      Class::Inspector 1.32
+      Class::Inspector::Functions 1.32
+    requirements:
+      ExtUtils::MakeMaker 0
+      File::Spec 0.80
+      perl 5.006
+  Class-Singleton-1.5
+    pathname: S/SH/SHAY/Class-Singleton-1.5.tar.gz
+    provides:
+      Class::Singleton 1.5
+    requirements:
+      ExtUtils::MakeMaker 0
+  Clone-PP-1.07
+    pathname: N/NE/NEILB/Clone-PP-1.07.tar.gz
+    provides:
+      Clone::PP 1.07
+    requirements:
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      perl 5.006
+      strict 0
+      vars 0
+      warnings 0
+  DBD-Pg-3.7.0
+    pathname: T/TU/TURNSTEP/DBD-Pg-3.7.0.tar.gz
+    provides:
+      Bundle::DBD::Pg v3.7.0
+      DBD::Pg v3.7.0
+    requirements:
+      DBI 1.614
+      ExtUtils::MakeMaker 6.11
+      Test::More 0.88
+      Time::HiRes 0
+      version 0
+  DBI-1.637
+    pathname: T/TI/TIMB/DBI-1.637.tar.gz
+    provides:
+      Bundle::DBI 12.008696
+      DBD::DBM 0.08
+      DBD::DBM::Statement 0.08
+      DBD::DBM::Table 0.08
+      DBD::DBM::db 0.08
+      DBD::DBM::dr 0.08
+      DBD::DBM::st 0.08
+      DBD::ExampleP 12.014311
+      DBD::ExampleP::db 12.014311
+      DBD::ExampleP::dr 12.014311
+      DBD::ExampleP::st 12.014311
+      DBD::File 0.44
+      DBD::File::DataSource::File 0.44
+      DBD::File::DataSource::Stream 0.44
+      DBD::File::Statement 0.44
+      DBD::File::Table 0.44
+      DBD::File::TableSource::FileSystem 0.44
+      DBD::File::db 0.44
+      DBD::File::dr 0.44
+      DBD::File::st 0.44
+      DBD::Gofer 0.015327
+      DBD::Gofer::Policy::Base 0.010088
+      DBD::Gofer::Policy::classic 0.010088
+      DBD::Gofer::Policy::pedantic 0.010088
+      DBD::Gofer::Policy::rush 0.010088
+      DBD::Gofer::Transport::Base 0.014121
+      DBD::Gofer::Transport::corostream undef
+      DBD::Gofer::Transport::null 0.010088
+      DBD::Gofer::Transport::pipeone 0.010088
+      DBD::Gofer::Transport::stream 0.014599
+      DBD::Gofer::db 0.015327
+      DBD::Gofer::dr 0.015327
+      DBD::Gofer::st 0.015327
+      DBD::NullP 12.014715
+      DBD::NullP::db 12.014715
+      DBD::NullP::dr 12.014715
+      DBD::NullP::st 12.014715
+      DBD::Proxy 0.2004
+      DBD::Proxy::RPC::PlClient 0.2004
+      DBD::Proxy::db 0.2004
+      DBD::Proxy::dr 0.2004
+      DBD::Proxy::st 0.2004
+      DBD::Sponge 12.010003
+      DBD::Sponge::db 12.010003
+      DBD::Sponge::dr 12.010003
+      DBD::Sponge::st 12.010003
+      DBDI 12.015129
+      DBI 1.637
+      DBI::Const::GetInfo::ANSI 2.008697
+      DBI::Const::GetInfo::ODBC 2.011374
+      DBI::Const::GetInfoReturn 2.008697
+      DBI::Const::GetInfoType 2.008697
+      DBI::DBD 12.015129
+      DBI::DBD::Metadata 2.014214
+      DBI::DBD::SqlEngine 0.06
+      DBI::DBD::SqlEngine::DataSource 0.06
+      DBI::DBD::SqlEngine::Statement 0.06
+      DBI::DBD::SqlEngine::Table 0.06
+      DBI::DBD::SqlEngine::TableSource 0.06
+      DBI::DBD::SqlEngine::TieMeta 0.06
+      DBI::DBD::SqlEngine::TieTables 0.06
+      DBI::DBD::SqlEngine::db 0.06
+      DBI::DBD::SqlEngine::dr 0.06
+      DBI::DBD::SqlEngine::st 0.06
+      DBI::Gofer::Execute 0.014283
+      DBI::Gofer::Request 0.012537
+      DBI::Gofer::Response 0.011566
+      DBI::Gofer::Serializer::Base 0.009950
+      DBI::Gofer::Serializer::DataDumper 0.009950
+      DBI::Gofer::Serializer::Storable 0.015586
+      DBI::Gofer::Transport::Base 0.012537
+      DBI::Gofer::Transport::pipeone 0.012537
+      DBI::Gofer::Transport::stream 0.012537
+      DBI::Profile 2.015065
+      DBI::ProfileData 2.010008
+      DBI::ProfileDumper 2.015325
+      DBI::ProfileDumper::Apache 2.014121
+      DBI::ProfileSubs 0.009396
+      DBI::ProxyServer 0.3005
+      DBI::ProxyServer::db 0.3005
+      DBI::ProxyServer::dr 0.3005
+      DBI::ProxyServer::st 0.3005
+      DBI::SQL::Nano 1.015544
+      DBI::SQL::Nano::Statement_ 1.015544
+      DBI::SQL::Nano::Table_ 1.015544
+      DBI::Util::CacheMemory 0.010315
+      DBI::Util::_accessor 0.009479
+      DBI::common 1.637
+    requirements:
+      ExtUtils::MakeMaker 6.48
+      Test::Simple 0.90
+      perl 5.008
+  Data-Printer-0.40
+    pathname: G/GA/GARU/Data-Printer-0.40.tar.gz
+    provides:
+      DDP undef
+      Data::Printer 0.40
+      Data::Printer::Filter undef
+      Data::Printer::Filter::DB undef
+      Data::Printer::Filter::DateTime undef
+      Data::Printer::Filter::Digest undef
+    requirements:
+      Carp 0
+      Clone::PP 0
+      ExtUtils::MakeMaker 0
+      Fcntl 0
+      File::HomeDir 0.91
+      File::Spec 0
+      File::Temp 0
+      Package::Stash 0.3
+      Scalar::Util 0
+      Sort::Naturally 0
+      Term::ANSIColor 3
+      Test::More 0.88
+      version 0.77
+  DateTime-1.44
+    pathname: D/DR/DROLSKY/DateTime-1.44.tar.gz
+    provides:
+      DateTime 1.44
+      DateTime::Duration 1.44
+      DateTime::Helpers 1.44
+      DateTime::Infinite 1.44
+      DateTime::Infinite::Future 1.44
+      DateTime::Infinite::Past 1.44
+      DateTime::LeapSecond 1.44
+      DateTime::PP 1.44
+      DateTime::PPExtra 1.44
+      DateTime::Types 1.44
+    requirements:
+      Carp 0
+      DateTime::Locale 1.06
+      DateTime::TimeZone 2.02
+      Dist::CheckConflicts 0.02
+      ExtUtils::MakeMaker 0
+      POSIX 0
+      Params::ValidationCompiler 0.13
+      Scalar::Util 0
+      Specio 0.18
+      Specio::Declare 0
+      Specio::Exporter 0
+      Specio::Library::Builtins 0
+      Specio::Library::Numeric 0
+      Specio::Library::String 0
+      Try::Tiny 0
+      XSLoader 0
+      base 0
+      integer 0
+      namespace::autoclean 0.19
+      overload 0
+      parent 0
+      perl 5.008004
+      strict 0
+      warnings 0
+      warnings::register 0
+  DateTime-Format-Builder-0.81
+    pathname: D/DR/DROLSKY/DateTime-Format-Builder-0.81.tar.gz
+    provides:
+      DateTime::Format::Builder 0.81
+      DateTime::Format::Builder::Parser 0.81
+      DateTime::Format::Builder::Parser::Dispatch 0.81
+      DateTime::Format::Builder::Parser::Quick 0.81
+      DateTime::Format::Builder::Parser::Regex 0.81
+      DateTime::Format::Builder::Parser::Strptime 0.81
+      DateTime::Format::Builder::Parser::generic 0.81
+      DateTime::Format::Fall undef
+      DateTime::Format::Simple undef
+    requirements:
+      Carp 0
+      Class::Factory::Util 1.6
+      DateTime 1.00
+      DateTime::Format::Strptime 1.04
+      ExtUtils::MakeMaker 6.30
+      Params::Validate 0.72
+      Scalar::Util 0
+      base 0
+      strict 0
+      vars 0
+      warnings 0
+  DateTime-Format-Pg-0.16013
+    pathname: D/DM/DMAKI/DateTime-Format-Pg-0.16013.tar.gz
+    provides:
+      DateTime::Format::Pg 0.16013
+    requirements:
+      DateTime 0.10
+      DateTime::Format::Builder 0.72
+      DateTime::TimeZone 0.05
+      ExtUtils::MakeMaker 6.36
+      Module::Build::Tiny 0.035
+      Test::More 0
+  DateTime-Format-Strptime-1.74
+    pathname: D/DR/DROLSKY/DateTime-Format-Strptime-1.74.tar.gz
+    provides:
+      DateTime::Format::Strptime 1.74
+      DateTime::Format::Strptime::Types 1.74
+    requirements:
+      Carp 0
+      DateTime 1.00
+      DateTime::Locale 1.05
+      DateTime::Locale::Base 0
+      DateTime::Locale::FromData 0
+      DateTime::TimeZone 2.09
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Package::DeprecationManager 0.15
+      Params::ValidationCompiler 0
+      Specio 0.33
+      Specio::Declare 0
+      Specio::Exporter 0
+      Specio::Library::Builtins 0
+      Specio::Library::String 0
+      Try::Tiny 0
+      constant 0
+      parent 0
+      strict 0
+      warnings 0
+  DateTime-Locale-1.17
+    pathname: D/DR/DROLSKY/DateTime-Locale-1.17.tar.gz
+    provides:
+      DateTime::Locale 1.17
+      DateTime::Locale::Base 1.17
+      DateTime::Locale::Catalog 1.17
+      DateTime::Locale::Data 1.17
+      DateTime::Locale::FromData 1.17
+      DateTime::Locale::Util 1.17
+    requirements:
+      Carp 0
+      Dist::CheckConflicts 0.02
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      File::ShareDir 0
+      File::ShareDir::Install 0.06
+      List::Util 1.45
+      Params::ValidationCompiler 0.13
+      Specio::Declare 0
+      Specio::Library::String 0
+      namespace::autoclean 0.19
+      perl 5.008004
+      strict 0
+      warnings 0
+  DateTime-TimeZone-2.15
+    pathname: D/DR/DROLSKY/DateTime-TimeZone-2.15.tar.gz
+    provides:
+      DateTime::TimeZone 2.15
+      DateTime::TimeZone::Africa::Abidjan 2.15
+      DateTime::TimeZone::Africa::Accra 2.15
+      DateTime::TimeZone::Africa::Algiers 2.15
+      DateTime::TimeZone::Africa::Bissau 2.15
+      DateTime::TimeZone::Africa::Cairo 2.15
+      DateTime::TimeZone::Africa::Casablanca 2.15
+      DateTime::TimeZone::Africa::Ceuta 2.15
+      DateTime::TimeZone::Africa::El_Aaiun 2.15
+      DateTime::TimeZone::Africa::Johannesburg 2.15
+      DateTime::TimeZone::Africa::Juba 2.15
+      DateTime::TimeZone::Africa::Khartoum 2.15
+      DateTime::TimeZone::Africa::Lagos 2.15
+      DateTime::TimeZone::Africa::Maputo 2.15
+      DateTime::TimeZone::Africa::Monrovia 2.15
+      DateTime::TimeZone::Africa::Nairobi 2.15
+      DateTime::TimeZone::Africa::Ndjamena 2.15
+      DateTime::TimeZone::Africa::Tripoli 2.15
+      DateTime::TimeZone::Africa::Tunis 2.15
+      DateTime::TimeZone::Africa::Windhoek 2.15
+      DateTime::TimeZone::America::Adak 2.15
+      DateTime::TimeZone::America::Anchorage 2.15
+      DateTime::TimeZone::America::Araguaina 2.15
+      DateTime::TimeZone::America::Argentina::Buenos_Aires 2.15
+      DateTime::TimeZone::America::Argentina::Catamarca 2.15
+      DateTime::TimeZone::America::Argentina::Cordoba 2.15
+      DateTime::TimeZone::America::Argentina::Jujuy 2.15
+      DateTime::TimeZone::America::Argentina::La_Rioja 2.15
+      DateTime::TimeZone::America::Argentina::Mendoza 2.15
+      DateTime::TimeZone::America::Argentina::Rio_Gallegos 2.15
+      DateTime::TimeZone::America::Argentina::Salta 2.15
+      DateTime::TimeZone::America::Argentina::San_Juan 2.15
+      DateTime::TimeZone::America::Argentina::San_Luis 2.15
+      DateTime::TimeZone::America::Argentina::Tucuman 2.15
+      DateTime::TimeZone::America::Argentina::Ushuaia 2.15
+      DateTime::TimeZone::America::Asuncion 2.15
+      DateTime::TimeZone::America::Atikokan 2.15
+      DateTime::TimeZone::America::Bahia 2.15
+      DateTime::TimeZone::America::Bahia_Banderas 2.15
+      DateTime::TimeZone::America::Barbados 2.15
+      DateTime::TimeZone::America::Belem 2.15
+      DateTime::TimeZone::America::Belize 2.15
+      DateTime::TimeZone::America::Blanc_Sablon 2.15
+      DateTime::TimeZone::America::Boa_Vista 2.15
+      DateTime::TimeZone::America::Bogota 2.15
+      DateTime::TimeZone::America::Boise 2.15
+      DateTime::TimeZone::America::Cambridge_Bay 2.15
+      DateTime::TimeZone::America::Campo_Grande 2.15
+      DateTime::TimeZone::America::Cancun 2.15
+      DateTime::TimeZone::America::Caracas 2.15
+      DateTime::TimeZone::America::Cayenne 2.15
+      DateTime::TimeZone::America::Chicago 2.15
+      DateTime::TimeZone::America::Chihuahua 2.15
+      DateTime::TimeZone::America::Costa_Rica 2.15
+      DateTime::TimeZone::America::Creston 2.15
+      DateTime::TimeZone::America::Cuiaba 2.15
+      DateTime::TimeZone::America::Curacao 2.15
+      DateTime::TimeZone::America::Danmarkshavn 2.15
+      DateTime::TimeZone::America::Dawson 2.15
+      DateTime::TimeZone::America::Dawson_Creek 2.15
+      DateTime::TimeZone::America::Denver 2.15
+      DateTime::TimeZone::America::Detroit 2.15
+      DateTime::TimeZone::America::Edmonton 2.15
+      DateTime::TimeZone::America::Eirunepe 2.15
+      DateTime::TimeZone::America::El_Salvador 2.15
+      DateTime::TimeZone::America::Fort_Nelson 2.15
+      DateTime::TimeZone::America::Fortaleza 2.15
+      DateTime::TimeZone::America::Glace_Bay 2.15
+      DateTime::TimeZone::America::Godthab 2.15
+      DateTime::TimeZone::America::Goose_Bay 2.15
+      DateTime::TimeZone::America::Grand_Turk 2.15
+      DateTime::TimeZone::America::Guatemala 2.15
+      DateTime::TimeZone::America::Guayaquil 2.15
+      DateTime::TimeZone::America::Guyana 2.15
+      DateTime::TimeZone::America::Halifax 2.15
+      DateTime::TimeZone::America::Havana 2.15
+      DateTime::TimeZone::America::Hermosillo 2.15
+      DateTime::TimeZone::America::Indiana::Indianapolis 2.15
+      DateTime::TimeZone::America::Indiana::Knox 2.15
+      DateTime::TimeZone::America::Indiana::Marengo 2.15
+      DateTime::TimeZone::America::Indiana::Petersburg 2.15
+      DateTime::TimeZone::America::Indiana::Tell_City 2.15
+      DateTime::TimeZone::America::Indiana::Vevay 2.15
+      DateTime::TimeZone::America::Indiana::Vincennes 2.15
+      DateTime::TimeZone::America::Indiana::Winamac 2.15
+      DateTime::TimeZone::America::Inuvik 2.15
+      DateTime::TimeZone::America::Iqaluit 2.15
+      DateTime::TimeZone::America::Jamaica 2.15
+      DateTime::TimeZone::America::Juneau 2.15
+      DateTime::TimeZone::America::Kentucky::Louisville 2.15
+      DateTime::TimeZone::America::Kentucky::Monticello 2.15
+      DateTime::TimeZone::America::La_Paz 2.15
+      DateTime::TimeZone::America::Lima 2.15
+      DateTime::TimeZone::America::Los_Angeles 2.15
+      DateTime::TimeZone::America::Maceio 2.15
+      DateTime::TimeZone::America::Managua 2.15
+      DateTime::TimeZone::America::Manaus 2.15
+      DateTime::TimeZone::America::Martinique 2.15
+      DateTime::TimeZone::America::Matamoros 2.15
+      DateTime::TimeZone::America::Mazatlan 2.15
+      DateTime::TimeZone::America::Menominee 2.15
+      DateTime::TimeZone::America::Merida 2.15
+      DateTime::TimeZone::America::Metlakatla 2.15
+      DateTime::TimeZone::America::Mexico_City 2.15
+      DateTime::TimeZone::America::Miquelon 2.15
+      DateTime::TimeZone::America::Moncton 2.15
+      DateTime::TimeZone::America::Monterrey 2.15
+      DateTime::TimeZone::America::Montevideo 2.15
+      DateTime::TimeZone::America::Nassau 2.15
+      DateTime::TimeZone::America::New_York 2.15
+      DateTime::TimeZone::America::Nipigon 2.15
+      DateTime::TimeZone::America::Nome 2.15
+      DateTime::TimeZone::America::Noronha 2.15
+      DateTime::TimeZone::America::North_Dakota::Beulah 2.15
+      DateTime::TimeZone::America::North_Dakota::Center 2.15
+      DateTime::TimeZone::America::North_Dakota::New_Salem 2.15
+      DateTime::TimeZone::America::Ojinaga 2.15
+      DateTime::TimeZone::America::Panama 2.15
+      DateTime::TimeZone::America::Pangnirtung 2.15
+      DateTime::TimeZone::America::Paramaribo 2.15
+      DateTime::TimeZone::America::Phoenix 2.15
+      DateTime::TimeZone::America::Port_au_Prince 2.15
+      DateTime::TimeZone::America::Port_of_Spain 2.15
+      DateTime::TimeZone::America::Porto_Velho 2.15
+      DateTime::TimeZone::America::Puerto_Rico 2.15
+      DateTime::TimeZone::America::Punta_Arenas 2.15
+      DateTime::TimeZone::America::Rainy_River 2.15
+      DateTime::TimeZone::America::Rankin_Inlet 2.15
+      DateTime::TimeZone::America::Recife 2.15
+      DateTime::TimeZone::America::Regina 2.15
+      DateTime::TimeZone::America::Resolute 2.15
+      DateTime::TimeZone::America::Rio_Branco 2.15
+      DateTime::TimeZone::America::Santarem 2.15
+      DateTime::TimeZone::America::Santiago 2.15
+      DateTime::TimeZone::America::Santo_Domingo 2.15
+      DateTime::TimeZone::America::Sao_Paulo 2.15
+      DateTime::TimeZone::America::Scoresbysund 2.15
+      DateTime::TimeZone::America::Sitka 2.15
+      DateTime::TimeZone::America::St_Johns 2.15
+      DateTime::TimeZone::America::Swift_Current 2.15
+      DateTime::TimeZone::America::Tegucigalpa 2.15
+      DateTime::TimeZone::America::Thule 2.15
+      DateTime::TimeZone::America::Thunder_Bay 2.15
+      DateTime::TimeZone::America::Tijuana 2.15
+      DateTime::TimeZone::America::Toronto 2.15
+      DateTime::TimeZone::America::Vancouver 2.15
+      DateTime::TimeZone::America::Whitehorse 2.15
+      DateTime::TimeZone::America::Winnipeg 2.15
+      DateTime::TimeZone::America::Yakutat 2.15
+      DateTime::TimeZone::America::Yellowknife 2.15
+      DateTime::TimeZone::Antarctica::Casey 2.15
+      DateTime::TimeZone::Antarctica::Davis 2.15
+      DateTime::TimeZone::Antarctica::DumontDUrville 2.15
+      DateTime::TimeZone::Antarctica::Macquarie 2.15
+      DateTime::TimeZone::Antarctica::Mawson 2.15
+      DateTime::TimeZone::Antarctica::Palmer 2.15
+      DateTime::TimeZone::Antarctica::Rothera 2.15
+      DateTime::TimeZone::Antarctica::Syowa 2.15
+      DateTime::TimeZone::Antarctica::Troll 2.15
+      DateTime::TimeZone::Antarctica::Vostok 2.15
+      DateTime::TimeZone::Asia::Almaty 2.15
+      DateTime::TimeZone::Asia::Amman 2.15
+      DateTime::TimeZone::Asia::Anadyr 2.15
+      DateTime::TimeZone::Asia::Aqtau 2.15
+      DateTime::TimeZone::Asia::Aqtobe 2.15
+      DateTime::TimeZone::Asia::Ashgabat 2.15
+      DateTime::TimeZone::Asia::Atyrau 2.15
+      DateTime::TimeZone::Asia::Baghdad 2.15
+      DateTime::TimeZone::Asia::Baku 2.15
+      DateTime::TimeZone::Asia::Bangkok 2.15
+      DateTime::TimeZone::Asia::Barnaul 2.15
+      DateTime::TimeZone::Asia::Beirut 2.15
+      DateTime::TimeZone::Asia::Bishkek 2.15
+      DateTime::TimeZone::Asia::Brunei 2.15
+      DateTime::TimeZone::Asia::Chita 2.15
+      DateTime::TimeZone::Asia::Choibalsan 2.15
+      DateTime::TimeZone::Asia::Colombo 2.15
+      DateTime::TimeZone::Asia::Damascus 2.15
+      DateTime::TimeZone::Asia::Dhaka 2.15
+      DateTime::TimeZone::Asia::Dili 2.15
+      DateTime::TimeZone::Asia::Dubai 2.15
+      DateTime::TimeZone::Asia::Dushanbe 2.15
+      DateTime::TimeZone::Asia::Famagusta 2.15
+      DateTime::TimeZone::Asia::Gaza 2.15
+      DateTime::TimeZone::Asia::Hebron 2.15
+      DateTime::TimeZone::Asia::Ho_Chi_Minh 2.15
+      DateTime::TimeZone::Asia::Hong_Kong 2.15
+      DateTime::TimeZone::Asia::Hovd 2.15
+      DateTime::TimeZone::Asia::Irkutsk 2.15
+      DateTime::TimeZone::Asia::Jakarta 2.15
+      DateTime::TimeZone::Asia::Jayapura 2.15
+      DateTime::TimeZone::Asia::Jerusalem 2.15
+      DateTime::TimeZone::Asia::Kabul 2.15
+      DateTime::TimeZone::Asia::Kamchatka 2.15
+      DateTime::TimeZone::Asia::Karachi 2.15
+      DateTime::TimeZone::Asia::Kathmandu 2.15
+      DateTime::TimeZone::Asia::Khandyga 2.15
+      DateTime::TimeZone::Asia::Kolkata 2.15
+      DateTime::TimeZone::Asia::Krasnoyarsk 2.15
+      DateTime::TimeZone::Asia::Kuala_Lumpur 2.15
+      DateTime::TimeZone::Asia::Kuching 2.15
+      DateTime::TimeZone::Asia::Macau 2.15
+      DateTime::TimeZone::Asia::Magadan 2.15
+      DateTime::TimeZone::Asia::Makassar 2.15
+      DateTime::TimeZone::Asia::Manila 2.15
+      DateTime::TimeZone::Asia::Nicosia 2.15
+      DateTime::TimeZone::Asia::Novokuznetsk 2.15
+      DateTime::TimeZone::Asia::Novosibirsk 2.15
+      DateTime::TimeZone::Asia::Omsk 2.15
+      DateTime::TimeZone::Asia::Oral 2.15
+      DateTime::TimeZone::Asia::Pontianak 2.15
+      DateTime::TimeZone::Asia::Pyongyang 2.15
+      DateTime::TimeZone::Asia::Qatar 2.15
+      DateTime::TimeZone::Asia::Qyzylorda 2.15
+      DateTime::TimeZone::Asia::Riyadh 2.15
+      DateTime::TimeZone::Asia::Sakhalin 2.15
+      DateTime::TimeZone::Asia::Samarkand 2.15
+      DateTime::TimeZone::Asia::Seoul 2.15
+      DateTime::TimeZone::Asia::Shanghai 2.15
+      DateTime::TimeZone::Asia::Singapore 2.15
+      DateTime::TimeZone::Asia::Srednekolymsk 2.15
+      DateTime::TimeZone::Asia::Taipei 2.15
+      DateTime::TimeZone::Asia::Tashkent 2.15
+      DateTime::TimeZone::Asia::Tbilisi 2.15
+      DateTime::TimeZone::Asia::Tehran 2.15
+      DateTime::TimeZone::Asia::Thimphu 2.15
+      DateTime::TimeZone::Asia::Tokyo 2.15
+      DateTime::TimeZone::Asia::Tomsk 2.15
+      DateTime::TimeZone::Asia::Ulaanbaatar 2.15
+      DateTime::TimeZone::Asia::Urumqi 2.15
+      DateTime::TimeZone::Asia::Ust_Nera 2.15
+      DateTime::TimeZone::Asia::Vladivostok 2.15
+      DateTime::TimeZone::Asia::Yakutsk 2.15
+      DateTime::TimeZone::Asia::Yangon 2.15
+      DateTime::TimeZone::Asia::Yekaterinburg 2.15
+      DateTime::TimeZone::Asia::Yerevan 2.15
+      DateTime::TimeZone::Atlantic::Azores 2.15
+      DateTime::TimeZone::Atlantic::Bermuda 2.15
+      DateTime::TimeZone::Atlantic::Canary 2.15
+      DateTime::TimeZone::Atlantic::Cape_Verde 2.15
+      DateTime::TimeZone::Atlantic::Faroe 2.15
+      DateTime::TimeZone::Atlantic::Madeira 2.15
+      DateTime::TimeZone::Atlantic::Reykjavik 2.15
+      DateTime::TimeZone::Atlantic::South_Georgia 2.15
+      DateTime::TimeZone::Atlantic::Stanley 2.15
+      DateTime::TimeZone::Australia::Adelaide 2.15
+      DateTime::TimeZone::Australia::Brisbane 2.15
+      DateTime::TimeZone::Australia::Broken_Hill 2.15
+      DateTime::TimeZone::Australia::Currie 2.15
+      DateTime::TimeZone::Australia::Darwin 2.15
+      DateTime::TimeZone::Australia::Eucla 2.15
+      DateTime::TimeZone::Australia::Hobart 2.15
+      DateTime::TimeZone::Australia::Lindeman 2.15
+      DateTime::TimeZone::Australia::Lord_Howe 2.15
+      DateTime::TimeZone::Australia::Melbourne 2.15
+      DateTime::TimeZone::Australia::Perth 2.15
+      DateTime::TimeZone::Australia::Sydney 2.15
+      DateTime::TimeZone::CET 2.15
+      DateTime::TimeZone::CST6CDT 2.15
+      DateTime::TimeZone::Catalog 2.15
+      DateTime::TimeZone::EET 2.15
+      DateTime::TimeZone::EST 2.15
+      DateTime::TimeZone::EST5EDT 2.15
+      DateTime::TimeZone::Europe::Amsterdam 2.15
+      DateTime::TimeZone::Europe::Andorra 2.15
+      DateTime::TimeZone::Europe::Astrakhan 2.15
+      DateTime::TimeZone::Europe::Athens 2.15
+      DateTime::TimeZone::Europe::Belgrade 2.15
+      DateTime::TimeZone::Europe::Berlin 2.15
+      DateTime::TimeZone::Europe::Brussels 2.15
+      DateTime::TimeZone::Europe::Bucharest 2.15
+      DateTime::TimeZone::Europe::Budapest 2.15
+      DateTime::TimeZone::Europe::Chisinau 2.15
+      DateTime::TimeZone::Europe::Copenhagen 2.15
+      DateTime::TimeZone::Europe::Dublin 2.15
+      DateTime::TimeZone::Europe::Gibraltar 2.15
+      DateTime::TimeZone::Europe::Helsinki 2.15
+      DateTime::TimeZone::Europe::Istanbul 2.15
+      DateTime::TimeZone::Europe::Kaliningrad 2.15
+      DateTime::TimeZone::Europe::Kiev 2.15
+      DateTime::TimeZone::Europe::Kirov 2.15
+      DateTime::TimeZone::Europe::Lisbon 2.15
+      DateTime::TimeZone::Europe::London 2.15
+      DateTime::TimeZone::Europe::Luxembourg 2.15
+      DateTime::TimeZone::Europe::Madrid 2.15
+      DateTime::TimeZone::Europe::Malta 2.15
+      DateTime::TimeZone::Europe::Minsk 2.15
+      DateTime::TimeZone::Europe::Monaco 2.15
+      DateTime::TimeZone::Europe::Moscow 2.15
+      DateTime::TimeZone::Europe::Oslo 2.15
+      DateTime::TimeZone::Europe::Paris 2.15
+      DateTime::TimeZone::Europe::Prague 2.15
+      DateTime::TimeZone::Europe::Riga 2.15
+      DateTime::TimeZone::Europe::Rome 2.15
+      DateTime::TimeZone::Europe::Samara 2.15
+      DateTime::TimeZone::Europe::Saratov 2.15
+      DateTime::TimeZone::Europe::Simferopol 2.15
+      DateTime::TimeZone::Europe::Sofia 2.15
+      DateTime::TimeZone::Europe::Stockholm 2.15
+      DateTime::TimeZone::Europe::Tallinn 2.15
+      DateTime::TimeZone::Europe::Tirane 2.15
+      DateTime::TimeZone::Europe::Ulyanovsk 2.15
+      DateTime::TimeZone::Europe::Uzhgorod 2.15
+      DateTime::TimeZone::Europe::Vienna 2.15
+      DateTime::TimeZone::Europe::Vilnius 2.15
+      DateTime::TimeZone::Europe::Volgograd 2.15
+      DateTime::TimeZone::Europe::Warsaw 2.15
+      DateTime::TimeZone::Europe::Zaporozhye 2.15
+      DateTime::TimeZone::Europe::Zurich 2.15
+      DateTime::TimeZone::Floating 2.15
+      DateTime::TimeZone::HST 2.15
+      DateTime::TimeZone::Indian::Chagos 2.15
+      DateTime::TimeZone::Indian::Christmas 2.15
+      DateTime::TimeZone::Indian::Cocos 2.15
+      DateTime::TimeZone::Indian::Kerguelen 2.15
+      DateTime::TimeZone::Indian::Mahe 2.15
+      DateTime::TimeZone::Indian::Maldives 2.15
+      DateTime::TimeZone::Indian::Mauritius 2.15
+      DateTime::TimeZone::Indian::Reunion 2.15
+      DateTime::TimeZone::Local 2.15
+      DateTime::TimeZone::Local::Android 2.15
+      DateTime::TimeZone::Local::Unix 2.15
+      DateTime::TimeZone::Local::VMS 2.15
+      DateTime::TimeZone::MET 2.15
+      DateTime::TimeZone::MST 2.15
+      DateTime::TimeZone::MST7MDT 2.15
+      DateTime::TimeZone::OffsetOnly 2.15
+      DateTime::TimeZone::OlsonDB 2.15
+      DateTime::TimeZone::OlsonDB::Change 2.15
+      DateTime::TimeZone::OlsonDB::Observance 2.15
+      DateTime::TimeZone::OlsonDB::Rule 2.15
+      DateTime::TimeZone::OlsonDB::Zone 2.15
+      DateTime::TimeZone::PST8PDT 2.15
+      DateTime::TimeZone::Pacific::Apia 2.15
+      DateTime::TimeZone::Pacific::Auckland 2.15
+      DateTime::TimeZone::Pacific::Bougainville 2.15
+      DateTime::TimeZone::Pacific::Chatham 2.15
+      DateTime::TimeZone::Pacific::Chuuk 2.15
+      DateTime::TimeZone::Pacific::Easter 2.15
+      DateTime::TimeZone::Pacific::Efate 2.15
+      DateTime::TimeZone::Pacific::Enderbury 2.15
+      DateTime::TimeZone::Pacific::Fakaofo 2.15
+      DateTime::TimeZone::Pacific::Fiji 2.15
+      DateTime::TimeZone::Pacific::Funafuti 2.15
+      DateTime::TimeZone::Pacific::Galapagos 2.15
+      DateTime::TimeZone::Pacific::Gambier 2.15
+      DateTime::TimeZone::Pacific::Guadalcanal 2.15
+      DateTime::TimeZone::Pacific::Guam 2.15
+      DateTime::TimeZone::Pacific::Honolulu 2.15
+      DateTime::TimeZone::Pacific::Kiritimati 2.15
+      DateTime::TimeZone::Pacific::Kosrae 2.15
+      DateTime::TimeZone::Pacific::Kwajalein 2.15
+      DateTime::TimeZone::Pacific::Majuro 2.15
+      DateTime::TimeZone::Pacific::Marquesas 2.15
+      DateTime::TimeZone::Pacific::Nauru 2.15
+      DateTime::TimeZone::Pacific::Niue 2.15
+      DateTime::TimeZone::Pacific::Norfolk 2.15
+      DateTime::TimeZone::Pacific::Noumea 2.15
+      DateTime::TimeZone::Pacific::Pago_Pago 2.15
+      DateTime::TimeZone::Pacific::Palau 2.15
+      DateTime::TimeZone::Pacific::Pitcairn 2.15
+      DateTime::TimeZone::Pacific::Pohnpei 2.15
+      DateTime::TimeZone::Pacific::Port_Moresby 2.15
+      DateTime::TimeZone::Pacific::Rarotonga 2.15
+      DateTime::TimeZone::Pacific::Tahiti 2.15
+      DateTime::TimeZone::Pacific::Tarawa 2.15
+      DateTime::TimeZone::Pacific::Tongatapu 2.15
+      DateTime::TimeZone::Pacific::Wake 2.15
+      DateTime::TimeZone::Pacific::Wallis 2.15
+      DateTime::TimeZone::UTC 2.15
+      DateTime::TimeZone::WET 2.15
+    requirements:
+      Class::Singleton 1.03
+      Cwd 3
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      File::Compare 0
+      File::Find 0
+      File::Spec 0
+      List::Util 1.33
+      Module::Runtime 0
+      Params::ValidationCompiler 0.13
+      Specio::Library::Builtins 0
+      Specio::Library::String 0
+      Try::Tiny 0
+      constant 0
+      namespace::autoclean 0
+      parent 0
+      perl 5.008004
+      strict 0
+      warnings 0
+  Devel-StackTrace-2.03
+    pathname: D/DR/DROLSKY/Devel-StackTrace-2.03.tar.gz
+    provides:
+      Devel::StackTrace 2.03
+      Devel::StackTrace::Frame 2.03
+    requirements:
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      Scalar::Util 0
+      overload 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Dist-CheckConflicts-0.11
+    pathname: D/DO/DOY/Dist-CheckConflicts-0.11.tar.gz
+    provides:
+      Dist::CheckConflicts 0.11
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 6.30
+      Module::Runtime 0.009
+      base 0
+      strict 0
+      warnings 0
+  Eval-Closure-0.14
+    pathname: D/DO/DOY/Eval-Closure-0.14.tar.gz
+    provides:
+      Eval::Closure 0.14
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Scalar::Util 0
+      constant 0
+      overload 0
+      strict 0
+      warnings 0
+  Exception-Class-1.44
+    pathname: D/DR/DROLSKY/Exception-Class-1.44.tar.gz
+    provides:
+      Exception::Class 1.44
+      Exception::Class::Base 1.44
+    requirements:
+      Class::Data::Inheritable 0.02
+      Devel::StackTrace 2.00
+      ExtUtils::MakeMaker 0
+      Scalar::Util 0
+      base 0
+      overload 0
+      perl 5.008001
+      strict 0
+      warnings 0
+  ExtUtils-Config-0.008
+    pathname: L/LE/LEONT/ExtUtils-Config-0.008.tar.gz
+    provides:
+      ExtUtils::Config 0.008
+    requirements:
+      Data::Dumper 0
+      ExtUtils::MakeMaker 6.30
+      strict 0
+      warnings 0
+  ExtUtils-Helpers-0.026
+    pathname: L/LE/LEONT/ExtUtils-Helpers-0.026.tar.gz
+    provides:
+      ExtUtils::Helpers 0.026
+      ExtUtils::Helpers::Unix 0.026
+      ExtUtils::Helpers::VMS 0.026
+      ExtUtils::Helpers::Windows 0.026
+    requirements:
+      Carp 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      File::Copy 0
+      File::Spec::Functions 0
+      Text::ParseWords 3.24
+      perl 5.006
+      strict 0
+      warnings 0
+  ExtUtils-InstallPaths-0.011
+    pathname: L/LE/LEONT/ExtUtils-InstallPaths-0.011.tar.gz
+    provides:
+      ExtUtils::InstallPaths 0.011
+    requirements:
+      Carp 0
+      ExtUtils::Config 0.002
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      perl 5.006
+      strict 0
+      warnings 0
+  File-HomeDir-1.002
+    pathname: R/RE/REHSACK/File-HomeDir-1.002.tar.gz
+    provides:
+      File::HomeDir 1.002
+      File::HomeDir::Darwin 1.002
+      File::HomeDir::Darwin::Carbon 1.002
+      File::HomeDir::Darwin::Cocoa 1.002
+      File::HomeDir::Driver 1.002
+      File::HomeDir::FreeDesktop 1.002
+      File::HomeDir::MacOS9 1.002
+      File::HomeDir::TIE 1.002
+      File::HomeDir::Test 1.002
+      File::HomeDir::Unix 1.002
+      File::HomeDir::Windows 1.002
+    requirements:
+      Carp 0
+      Cwd 3
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      File::Path 2.01
+      File::Spec 3
+      File::Temp 0.19
+      File::Which 0.05
+      Mac::SystemDirectory 0.04
+      POSIX 0
+      perl 5.005003
+  File-ShareDir-1.104
+    pathname: R/RE/REHSACK/File-ShareDir-1.104.tar.gz
+    provides:
+      File::ShareDir 1.104
+    requirements:
+      Carp 0
+      Class::Inspector 1.12
+      ExtUtils::MakeMaker 0
+      File::ShareDir::Install 0.03
+      File::Spec 0.80
+      perl 5.008001
+      warnings 0
+  File-ShareDir-Install-0.11
+    pathname: E/ET/ETHER/File-ShareDir-Install-0.11.tar.gz
+    provides:
+      File::ShareDir::Install 0.11
+    requirements:
+      Carp 0
+      Exporter 0
+      File::Spec 0
+      IO::Dir 0
+      Module::Build::Tiny 0.034
+      perl 5.008
+      strict 0
+      warnings 0
+  File-Which-1.22
+    pathname: P/PL/PLICEASE/File-Which-1.22.tar.gz
+    provides:
+      File::Which 1.22
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.006
+  MRO-Compat-0.13
+    pathname: H/HA/HAARG/MRO-Compat-0.13.tar.gz
+    provides:
+      MRO::Compat 0.13
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.006
+  Mac-SystemDirectory-0.10
+    pathname: E/ET/ETHER/Mac-SystemDirectory-0.10.tar.gz
+    provides:
+      Mac::SystemDirectory 0.10
+    requirements:
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      XSLoader 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Module-Build-0.4224
+    pathname: L/LE/LEONT/Module-Build-0.4224.tar.gz
+    provides:
+      Module::Build 0.4224
+      Module::Build::Base 0.4224
+      Module::Build::Compat 0.4224
+      Module::Build::Config 0.4224
+      Module::Build::Cookbook 0.4224
+      Module::Build::Dumper 0.4224
+      Module::Build::Notes 0.4224
+      Module::Build::PPMMaker 0.4224
+      Module::Build::Platform::Default 0.4224
+      Module::Build::Platform::MacOS 0.4224
+      Module::Build::Platform::Unix 0.4224
+      Module::Build::Platform::VMS 0.4224
+      Module::Build::Platform::VOS 0.4224
+      Module::Build::Platform::Windows 0.4224
+      Module::Build::Platform::aix 0.4224
+      Module::Build::Platform::cygwin 0.4224
+      Module::Build::Platform::darwin 0.4224
+      Module::Build::Platform::os2 0.4224
+      Module::Build::PodParser 0.4224
+    requirements:
+      CPAN::Meta 2.142060
+      CPAN::Meta::YAML 0.003
+      Cwd 0
+      Data::Dumper 0
+      ExtUtils::CBuilder 0.27
+      ExtUtils::Install 0
+      ExtUtils::Manifest 0
+      ExtUtils::Mkbootstrap 0
+      ExtUtils::ParseXS 2.21
+      File::Basename 0
+      File::Compare 0
+      File::Copy 0
+      File::Find 0
+      File::Path 0
+      File::Spec 0.82
+      File::Temp 0.15
+      Getopt::Long 0
+      Module::Metadata 1.000002
+      Parse::CPAN::Meta 1.4401
+      Perl::OSType 1
+      Pod::Man 2.17
+      TAP::Harness 3.29
+      Test::More 0.49
+      Text::Abbrev 0
+      Text::ParseWords 0
+      perl 5.006001
+      version 0.87
+  Module-Build-Tiny-0.039
+    pathname: L/LE/LEONT/Module-Build-Tiny-0.039.tar.gz
+    provides:
+      Module::Build::Tiny 0.039
+    requirements:
+      CPAN::Meta 0
+      DynaLoader 0
+      Exporter 5.57
+      ExtUtils::CBuilder 0
+      ExtUtils::Config 0.003
+      ExtUtils::Helpers 0.020
+      ExtUtils::Install 0
+      ExtUtils::InstallPaths 0.002
+      ExtUtils::ParseXS 0
+      File::Basename 0
+      File::Find 0
+      File::Path 0
+      File::Spec::Functions 0
+      Getopt::Long 2.36
+      JSON::PP 2
+      Pod::Man 0
+      TAP::Harness::Env 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Module-Implementation-0.09
+    pathname: D/DR/DROLSKY/Module-Implementation-0.09.tar.gz
+    provides:
+      Module::Implementation 0.09
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
+      Module::Runtime 0.012
+      Try::Tiny 0
+      strict 0
+      warnings 0
+  Module-Runtime-0.016
+    pathname: Z/ZE/ZEFRAM/Module-Runtime-0.016.tar.gz
+    provides:
+      Module::Runtime 0.016
+    requirements:
+      Module::Build 0
+      Test::More 0.41
+      perl 5.006
+      strict 0
+      warnings 0
+  Package-DeprecationManager-0.17
+    pathname: D/DR/DROLSKY/Package-DeprecationManager-0.17.tar.gz
+    provides:
+      Package::DeprecationManager 0.17
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
+      List::Util 1.33
+      Package::Stash 0
+      Params::Util 0
+      Sub::Install 0
+      Sub::Name 0
+      strict 0
+      warnings 0
+  Package-Stash-0.37
+    pathname: D/DO/DOY/Package-Stash-0.37.tar.gz
+    provides:
+      Package::Stash 0.37
+      Package::Stash::PP 0.37
+    requirements:
+      B 0
+      Carp 0
+      Config 0
+      Dist::CheckConflicts 0.02
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      Getopt::Long 0
+      Module::Implementation 0.06
+      Package::Stash::XS 0.26
+      Scalar::Util 0
+      Symbol 0
+      Text::ParseWords 0
+      constant 0
+      strict 0
+      warnings 0
+  Package-Stash-XS-0.28
+    pathname: D/DO/DOY/Package-Stash-XS-0.28.tar.gz
+    provides:
+      Package::Stash::XS 0.28
+    requirements:
+      ExtUtils::MakeMaker 6.30
+      XSLoader 0
+      strict 0
+      warnings 0
+  Params-Util-1.07
+    pathname: A/AD/ADAMK/Params-Util-1.07.tar.gz
+    provides:
+      Params::Util 1.07
+    requirements:
+      ExtUtils::CBuilder 0.27
+      ExtUtils::MakeMaker 6.52
+      File::Spec 0.80
+      Scalar::Util 1.18
+      Test::More 0.42
+      perl 5.00503
+  Params-Validate-1.29
+    pathname: D/DR/DROLSKY/Params-Validate-1.29.tar.gz
+    provides:
+      Params::Validate 1.29
+      Params::Validate::Constants 1.29
+      Params::Validate::PP 1.29
+      Params::Validate::XS 1.29
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::CBuilder 0
+      Module::Build 0.28
+      Module::Implementation 0
+      Scalar::Util 1.10
+      XSLoader 0
+      perl 5.008001
+      strict 0
+      vars 0
+      warnings 0
+  Params-ValidationCompiler-0.26
+    pathname: D/DR/DROLSKY/Params-ValidationCompiler-0.26.tar.gz
+    provides:
+      Params::ValidationCompiler 0.26
+      Params::ValidationCompiler::Compiler 0.26
+      Params::ValidationCompiler::Exceptions 0.26
+    requirements:
+      B 0
+      Carp 0
+      Eval::Closure 0
+      Exception::Class 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      List::Util 1.29
+      Scalar::Util 0
+      overload 0
+      strict 0
+      warnings 0
+  Role-Tiny-2.000006
+    pathname: H/HA/HAARG/Role-Tiny-2.000006.tar.gz
+    provides:
+      Role::Tiny 2.000006
+      Role::Tiny::With 2.000006
+    requirements:
+      Exporter 5.57
+      perl 5.006
+  Sort-Naturally-1.03
+    pathname: B/BI/BINGOS/Sort-Naturally-1.03.tar.gz
+    provides:
+      Sort::Naturally 1.03
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5
+  Specio-0.42
+    pathname: D/DR/DROLSKY/Specio-0.42.tar.gz
+    provides:
+      Specio 0.42
+      Specio::Coercion 0.42
+      Specio::Constraint::AnyCan 0.42
+      Specio::Constraint::AnyDoes 0.42
+      Specio::Constraint::AnyIsa 0.42
+      Specio::Constraint::Enum 0.42
+      Specio::Constraint::Intersection 0.42
+      Specio::Constraint::ObjectCan 0.42
+      Specio::Constraint::ObjectDoes 0.42
+      Specio::Constraint::ObjectIsa 0.42
+      Specio::Constraint::Parameterizable 0.42
+      Specio::Constraint::Parameterized 0.42
+      Specio::Constraint::Role::CanType 0.42
+      Specio::Constraint::Role::DoesType 0.42
+      Specio::Constraint::Role::Interface 0.42
+      Specio::Constraint::Role::IsaType 0.42
+      Specio::Constraint::Simple 0.42
+      Specio::Constraint::Structurable 0.42
+      Specio::Constraint::Structured 0.42
+      Specio::Constraint::Union 0.42
+      Specio::Declare 0.42
+      Specio::DeclaredAt 0.42
+      Specio::Exception 0.42
+      Specio::Exporter 0.42
+      Specio::Helpers 0.42
+      Specio::Library::Builtins 0.42
+      Specio::Library::Numeric 0.42
+      Specio::Library::Perl 0.42
+      Specio::Library::String 0.42
+      Specio::Library::Structured 0.42
+      Specio::Library::Structured::Dict 0.42
+      Specio::Library::Structured::Map 0.42
+      Specio::Library::Structured::Tuple 0.42
+      Specio::OO 0.42
+      Specio::PartialDump 0.42
+      Specio::Registry 0.42
+      Specio::Role::Inlinable 0.42
+      Specio::Subs 0.42
+      Specio::TypeChecks 0.42
+      Test::Specio 0.42
+    requirements:
+      B 0
+      Carp 0
+      Devel::StackTrace 0
+      Eval::Closure 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      IO::File 0
+      List::Util 1.33
+      MRO::Compat 0
+      Module::Runtime 0
+      Role::Tiny 1.003003
+      Role::Tiny::With 0
+      Scalar::Util 0
+      Storable 0
+      Sub::Quote 0
+      Test::Fatal 0
+      Test::More 0.96
+      Try::Tiny 0
+      overload 0
+      parent 0
+      perl 5.008
+      re 0
+      strict 0
+      version 0.83
+      warnings 0
+  Sub-Exporter-Progressive-0.001013
+    pathname: F/FR/FREW/Sub-Exporter-Progressive-0.001013.tar.gz
+    provides:
+      Sub::Exporter::Progressive 0.001013
+    requirements:
+      ExtUtils::MakeMaker 0
+  Sub-Identify-0.14
+    pathname: R/RG/RGARCIA/Sub-Identify-0.14.tar.gz
+    provides:
+      Sub::Identify 0.14
+    requirements:
+      ExtUtils::MakeMaker 0
+      Test::More 0
+  Sub-Install-0.928
+    pathname: R/RJ/RJBS/Sub-Install-0.928.tar.gz
+    provides:
+      Sub::Install 0.928
+    requirements:
+      B 0
+      Carp 0
+      ExtUtils::MakeMaker 6.30
+      Scalar::Util 0
+      strict 0
+      warnings 0
+  Sub-Name-0.21
+    pathname: E/ET/ETHER/Sub-Name-0.21.tar.gz
+    provides:
+      Sub::Name 0.21
+    requirements:
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      XSLoader 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Sub-Quote-2.004000
+    pathname: H/HA/HAARG/Sub-Quote-2.004000.tar.gz
+    provides:
+      Sub::Defer 2.004000
+      Sub::Quote 2.004000
+    requirements:
+      ExtUtils::MakeMaker 0
+      Scalar::Util 0
+      perl 5.006
+  Test-Fatal-0.014
+    pathname: R/RJ/RJBS/Test-Fatal-0.014.tar.gz
+    provides:
+      Test::Fatal 0.014
+    requirements:
+      Carp 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      Test::Builder 0
+      Try::Tiny 0.07
+      strict 0
+      warnings 0
+  Try-Tiny-0.28
+    pathname: E/ET/ETHER/Try-Tiny-0.28.tar.gz
+    provides:
+      Try::Tiny 0.28
+    requirements:
+      Carp 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      constant 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Variable-Magic-0.62
+    pathname: V/VP/VPIT/Variable-Magic-0.62.tar.gz
+    provides:
+      Variable::Magic 0.62
+    requirements:
+      Carp 0
+      Config 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      IO::Handle 0
+      IO::Select 0
+      IPC::Open3 0
+      POSIX 0
+      Socket 0
+      Test::More 0
+      XSLoader 0
+      base 0
+      lib 0
+      perl 5.008
+  namespace-autoclean-0.28
+    pathname: E/ET/ETHER/namespace-autoclean-0.28.tar.gz
+    provides:
+      namespace::autoclean 0.28
+    requirements:
+      B::Hooks::EndOfScope 0.12
+      ExtUtils::MakeMaker 0
+      List::Util 0
+      Sub::Identify 0
+      namespace::clean 0.20
+      perl 5.006
+      strict 0
+      warnings 0
+  namespace-clean-0.27
+    pathname: R/RI/RIBASUSHI/namespace-clean-0.27.tar.gz
+    provides:
+      namespace::clean 0.27
+    requirements:
+      B::Hooks::EndOfScope 0.12
+      ExtUtils::MakeMaker 0
+      Package::Stash 0.23
+      perl 5.008001

--- a/report/manta_jobs/time_to_earliest_remediation/filter_redundant_results.js
+++ b/report/manta_jobs/time_to_earliest_remediation/filter_redundant_results.js
@@ -1,0 +1,28 @@
+// filter out all but the first pass or failure for each device:component_type
+var fs = require('fs');
+var readline = require('readline');
+
+var deviceMap = {};
+
+var reader = readline.createInterface({
+    input: process.stdin,
+    output: process.stderr
+});
+
+reader.on('line', function (line) {
+    var obj = JSON.parse(line);
+    var deviceId = obj.device_id;
+    var componentName = obj.validation_result.component_name;
+    var validStatus = obj.validation_result.status;
+
+    if (! ((deviceMap[deviceId] || {})[componentName] || {})[validStatus]) {
+        if (! deviceMap[deviceId])
+            deviceMap[deviceId] = {};
+        if (! deviceMap[deviceId][componentName])
+            deviceMap[deviceId][componentName] = {};
+
+        deviceMap[deviceId][componentName][validStatus] = true;
+        process.stdout.write(line + '\n');
+    }
+
+});

--- a/report/manta_jobs/time_to_earliest_remediation/job.json
+++ b/report/manta_jobs/time_to_earliest_remediation/job.json
@@ -1,0 +1,12 @@
+[
+    {
+        "type": "map",
+        "assets": [ "/$MANTA_USER/stor/time_to_earliest_remediation/filter_redundant_results.js" ],
+        "exec": "node /assets/$MANTA_USER/stor/time_to_earliest_remediation/filter_redundant_results.js"
+    },
+    {
+        "type": "reduce",
+        "assets": [ "/$MANTA_USER/stor/time_to_earliest_remediation/reduce_first_failure_and_pass.js" ],
+        "exec": "node /assets/$MANTA_USER/stor/time_to_earliest_remediation/reduce_first_failure_and_pass.js"
+    }
+]

--- a/report/manta_jobs/time_to_earliest_remediation/reduce_first_failure_and_pass.js
+++ b/report/manta_jobs/time_to_earliest_remediation/reduce_first_failure_and_pass.js
@@ -1,0 +1,57 @@
+// find the first failure and first pass for each device:component_name
+var fs = require('fs');
+var readline = require('readline');
+
+var deviceMap = {};
+
+var reader = readline.createInterface({
+    input: process.stdin,
+    output: process.stderr
+});
+
+reader.on('line', function (line) {
+    var obj = JSON.parse(line);
+    var deviceId = obj.device_id;
+    var componentName = obj.validation_result.component_name;
+    var validStatus = obj.validation_result.status;
+    var created = new Date(obj.created);
+    // replace the string timestamp with the date object
+    obj.created = created;
+
+    var earliestFailure =
+        ((deviceMap[deviceId] || {})[componentName] || {}).first_fail;
+    var earliestSuccess =
+        ((deviceMap[deviceId] || {})[componentName] || {}).first_pass;
+
+
+    if (validStatus === 0) {
+        if (! earliestFailure) {
+            if (! deviceMap[deviceId])
+                deviceMap[deviceId] = {};
+            if (! deviceMap[deviceId][componentName])
+                deviceMap[deviceId][componentName] = {};
+
+            deviceMap[deviceId][componentName].first_fail = obj;
+            deviceMap[deviceId][componentName].first_pass = null;
+        }
+        else if (earliestFailure.created > created) {
+            deviceMap[deviceId][componentName].first_fail = obj;
+        }
+    }
+    else if (validStatus === 1 &&
+        earliestFailure &&
+        earliestFailure.created < created)
+    {
+        if (! earliestSuccess) {
+            // deviceMap is expected to be built because of earliestFailure
+            // precondition
+            deviceMap[deviceId][componentName].first_pass = obj;
+        }
+        else if (earliestSuccess.created > created) {
+            deviceMap[deviceId][componentName].first_pass = obj;
+        }
+    }
+}).on('close', function (){
+    process.stdout.write( JSON.stringify(deviceMap) );
+});
+


### PR DESCRIPTION
Seed the `report/` directory, which includes utilities and manta jobs
for analyzing Conch data.

Utilities:

* report/bin/device-validation-result-dump.pl - Dump Conch validation results
    to a directory with files split by dates. See
    `report/bin/device-validation-result-dump.pl --help` for information
    and options

* report/bin/upload_dir_to_manta.sh - Compress, upload, and decompress a
    directory to Manta

* report/bin/start_manta_job.sh - Start a manta job. Uploads any
    supporting files and scripts.

Manta job:

* report/manta_jobs/time_to_earliest_remediation - Manta job to find the
    first validation failure and validation success for each device
    component identified as failing