### PR TITLE
fix(api): add hardware vendor name to hardware product

### DIFF
--- a/Conch/docs/conch-api/openapi-spec.yaml
+++ b/Conch/docs/conch-api/openapi-spec.yaml
@@ -1436,6 +1436,9 @@ components:
             alias:
               type: string
               description: Hardware product alias
+            vendor:
+              type: string
+              description: Hardware product vendor name
     HardwareProduct:
       type: object
       properties:
@@ -1450,6 +1453,7 @@ components:
           type: string
         vendor:
           type: string
+          description: Hardware product vendor name
         profile:
           type: object
           properties:

--- a/Conch/lib/Conch/Control/Device.pm
+++ b/Conch/lib/Conch/Control/Device.pm
@@ -194,6 +194,7 @@ sub device_rack_location {
     $location->{target_hardware_product}{id}    = $target_hardware->id;
     $location->{target_hardware_product}{name}  = $target_hardware->name;
     $location->{target_hardware_product}{alias} = $target_hardware->alias;
+    $location->{target_hardware_product}{vendor} = $target_hardware->vendor->name;
 
     $location->{datacenter}{id}          = $datacenter->id;
     $location->{datacenter}{name}        = $datacenter->az;
@@ -219,7 +220,7 @@ sub get_target_hardware_product {
       'datacenter_rack_layouts.rack_id'  => $rack_id,
       'datacenter_rack_layouts.ru_start' => $rack_unit
     },
-    { join => 'datacenter_rack_layouts' }
+    { join => 'datacenter_rack_layouts'}
   )->single;
 }
 


### PR DESCRIPTION
Adds it to the responses of GET /hardware_product, GET
/hardware_product/:id, and the `target_hardware_product` object of the
Device location object.