### PR TITLE
feat(api): add password reset endpoint POST /password_reset

### DIFF
--- a/Conch/docs/conch-api/openapi-spec.yaml
+++ b/Conch/docs/conch-api/openapi-spec.yaml
@@ -69,6 +69,36 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /login:
+    post:
+      tags: [Login]
+      summary: Reset user password
+      security: []
+      operationId: resetPassword
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  description: Email address of the user to password reset
+              required:
+                - email
+      responses:
+        '204':
+          description: >
+            Password reset email has been sent if the email was associated with
+            a user account. Response will be identical if the email was not
+            found.
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /workspace:
     get:
       tags: [Workspace]

--- a/Conch/lib/Conch/Control/Workspace.pm
+++ b/Conch/lib/Conch/Control/Workspace.pm
@@ -9,7 +9,7 @@ use Mojo::Pg;
 use Mojo::Pg::Database;
 use SQL::Abstract;
 
-use Conch::Control::User qw( create_integrator_password hash_password );
+use Conch::Control::User qw( generate_random_password hash_password );
 
 use Exporter 'import';
 our @EXPORT = qw(
@@ -158,18 +158,17 @@ sub invite_user_to_workspace {
           { %$user, workspace_name => $workspace->{name} } );
       }
       else {
-        my $password      = create_integrator_password();
-        my $password_hash = hash_password($password);
+        my $pw = generate_random_password();
         $user = $db->insert(
           'user_account',
           {
             name          => $email,
             email         => $email,
-            password_hash => $password_hash
+            password_hash => $pw->{password_hash}
           },
           { returning => [ 'id', 'name', 'email' ] }
         )->hash;
-        $invite_new_user->( { %$user, password => $password } );
+        $invite_new_user->( { %$user, password => $pw->{password} } );
 
       }
 

--- a/Conch/lib/Conch/Mail.pm
+++ b/Conch/lib/Conch/Mail.pm
@@ -9,7 +9,7 @@ use Log::Any '$log';
 
 use Exporter 'import';
 our @EXPORT = qw(
-  new_user_invite existing_user_invite 
+  new_user_invite existing_user_invite password_reset_email
 );
 
 sub new_user_invite {
@@ -25,7 +25,7 @@ sub new_user_invite {
     Message => qq{Hello,
 
     You have been invited to join Joyent Conch. An account has been created for
-    you. Please log into https://preflight.scloud.zone using the credentials
+    you. Please log into https://conch.joyent.us using the credentials
     below:
 
     Username: $username
@@ -57,9 +57,43 @@ sub existing_user_invite {
     Message => qq{Hello,
 
     You have been invited to join a new Joyent Conch workspace
-    "$workspace_name".  Please log into https://preflight.scloud.zone using
+    "$workspace_name".  Please log into https://conch.joyent.us using
     your existing account credentails with username '$username'. You can switch
     between available workspaces in the sidebar.
+
+    Thank you,
+    Joyent Build Ops Team
+    }
+
+  );
+  if ( sendmail %mail ) {
+    $log->info("Existing user invite successfully sent to $email.");
+  }
+  else {
+    $log->error("Sendmail error: $Mail::Sendmail::error");
+  }
+}
+
+sub password_reset_email {
+  my ($args)         = @_;
+  my $email          = $args->{email};
+  my $username       = $args->{name} || $email;
+  my $password       = $args->{password};
+
+  my %mail = (
+    To      => $email,
+    From    => 'noreply@conch.joyent.us',
+    Subject => "Conch Password Reset",
+    Message => qq{Hello,
+
+    A request was received to reset your password.  A new password has been
+    randomly generated and your old password has been deactivated.
+
+    Please log into https://conch.joyent.us using the following credentials:
+
+    Username: $username
+    Password: $password
+
 
     Thank you,
     Joyent Build Ops Team

--- a/Conch/lib/Conch/Route/User.pm
+++ b/Conch/lib/Conch/Route/User.pm
@@ -12,6 +12,7 @@ use Hash::MultiValue;
 use HTTP::Headers::ActionPack::Authorization::Basic;
 
 use Conch::Control::User;
+use Conch::Mail qw( password_reset_email );
 use Conch::Control::User::Setting;
 
 use Data::Printer;
@@ -64,6 +65,18 @@ post '/login' => sub {
 post '/logout' => sub {
   session->destroy_session;
   status_200( { status => "logged out" } );
+};
+
+post '/reset_password' => sub {
+  my $username = body_parameters->get('email');
+  unless ( defined $email ) {
+    return status_400("'email' must be specified");
+  }
+  reset_user_password( schema, $email, \&password_reset_email );
+
+  # always return 200 whether or not the user exists so no information about
+  # the status of a user is given
+  status_200();
 };
 
 # used to check if the current user is authenticated


### PR DESCRIPTION
Jeff and others have been asking for a way to do reset a user's password. A new password is randomly generated and an email is sent to the user containing their new password.