### PR TITLE
fix: correct device report parsing error handling

### DIFF
--- a/Conch/lib/Conch/Controller/DeviceReport.pm
+++ b/Conch/lib/Conch/Controller/DeviceReport.pm
@@ -37,7 +37,7 @@ sub process ($c) {
 
 	#Log::Any->get_logger( category => 'report.raw' )
 	#->trace( encode_json $raw_report);
-	my $device_report;
+	my ($device_report, $errs);
 	try {
 		if ( $raw_report->{device_type} && $raw_report->{device_type} eq "switch" )
 		{
@@ -48,12 +48,10 @@ sub process ($c) {
 		}
 	}
 	catch {
-		my $errs = join( "; ", map { $_->message } $device_report->errors );
-
+		$errs = join( "; ", map { $_->message } $_->errors );
 		$c->app->log->error( 'Failed parsing device report: ' . $errs );
-
-		return $c->status( 400, { error => $errs } );
 	};
+	return $c->status( 400, { error => $errs } ) if $errs;
 
 	my $aux_report = dclone($raw_report);
 	for my $attr ( keys %{ $device_report->pack } ) {

--- a/Conch/t/integration/00_only_1_user_loaded.t
+++ b/Conch/t/integration/00_only_1_user_loaded.t
@@ -251,6 +251,9 @@ subtest 'Device Report' => sub {
 		io->file('t/integration/resource/passing-device-report.json')->slurp;
 	$t->post_ok( '/device/TEST', $report )->status_is(409)
 		->json_like( '/error', qr/Hardware Product '.+' does not exist/ );
+	
+	$t->post_ok( '/device/TEST', json => { serial_number => 'TEST' })
+		->status_is(400)->json_like('/error', qr/Attribute .* is required/);
 };
 
 subtest 'Single device' => sub {


### PR DESCRIPTION
Fix a regression to return 400 with a list of required attributes when parsing a device report fails.