### PR TITLE
fix /workspace/$id/user endpoint

### DIFF
--- a/lib/Conch/DB/ResultSet/UserAccount.pm
+++ b/lib/Conch/DB/ResultSet/UserAccount.pm
@@ -66,8 +66,8 @@ sub lookup_by_email {
 
     $self->active->search(
         [ \[ 'lower(email) = lower(?)', $email ] ],
-        { order_by => { -desc => 'created' } },
-    )->single;
+        { order_by => { -desc => 'created' }, rows => 1 },
+    )->first;
 }
 
 =head2 lookup_by_name

--- a/t/integration/00_only_1_user_loaded.t
+++ b/t/integration/00_only_1_user_loaded.t
@@ -234,6 +234,20 @@ subtest 'Workspaces' => sub {
 		"Workspace User Data Contract"
 	);
 
+	$t->post_ok("/workspace/$id/user?send_invite_mail=0" => json => {
+			user => 'test_workspace@conch.joyent.us',
+			role => 'rw',
+		})
+		->status_is(201);
+
+	is(
+		$t->app->db_user_accounts
+			->lookup_by_email('test_workspace@conch.joyent.us')
+			->search_related('user_workspace_roles', { workspace_id => $id })
+			->single->role,
+		'rw',
+		'new user can access this workspace',
+	);
 };
 
 subtest 'Sub-Workspace' => sub {


### PR DESCRIPTION
DBIx::Class::ResultSet::single(): single() can not be used on resultsets collapsing a has_many. Use find( \\%cond ) or next() instead at lib/Conch/DB/ResultSet/UserAccount.pm line 61