### PR TITLE
inflate hardware_product.specification in requests and responses

### DIFF
--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -644,15 +644,9 @@
           "$ref" : "common.json#/definitions/mojo_standard_placeholder"
         },
         "specification" : {
-          "$comment" : "json blob of additional data for hardware_product.specification (TO BE RESTRUCTURED SOON)",
           "oneOf" : [
             {
-              "$comment" : "Note that contentSchema is not validated automatically; the data must be json-decoded first and then the schema applied manually",
-              "contentMediaType" : "application/json",
-              "contentSchema" : {
-                "$ref" : "common.json#/definitions/HardwareProductSpecification"
-              },
-              "type" : "string"
+              "$ref" : "common.json#/definitions/HardwareProductSpecification"
             },
             {
               "type" : "null"

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -1609,15 +1609,9 @@
           "$ref" : "common.json#/definitions/mojo_standard_placeholder"
         },
         "specification" : {
-          "$comment" : "json blob of additional data for hardware_product.specification (TO BE RESTRUCTURED SOON)",
           "oneOf" : [
             {
-              "$comment" : "Note that contentSchema is not validated automatically; the data must be json-decoded first and then the schema applied manually",
-              "contentMediaType" : "application/json",
-              "contentSchema" : {
-                "$ref" : "common.json#/definitions/HardwareProductSpecification"
-              },
-              "type" : "string"
+              "$ref" : "common.json#/definitions/HardwareProductSpecification"
             },
             {
               "type" : "null"

--- a/docs/modules/Conch::DB::Result::HardwareProduct.md
+++ b/docs/modules/Conch::DB::Result::HardwareProduct.md
@@ -348,6 +348,10 @@ Type: has\_many
 
 Related object: [Conch::DB::Result::ValidationState](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AValidationState)
 
+### TO\_JSON
+
+Decode the json-encoded specification field for rendering in responses.
+
 ## LICENSING
 
 Copyright Joyent, Inc.

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -262,13 +262,8 @@ definitions:
       hardware_vendor_id:
         $ref: common.yaml#/definitions/uuid
       specification:
-        $comment: json blob of additional data for hardware_product.specification (TO BE RESTRUCTURED SOON)
         oneOf:
-          - $comment: Note that contentSchema is not validated automatically; the data must be json-decoded first and then the schema applied manually
-            type: string
-            contentMediaType: application/json
-            contentSchema:
-              $ref: common.yaml#/definitions/HardwareProductSpecification
+          - $ref: common.yaml#/definitions/HardwareProductSpecification
           - type: 'null'
       sku:
         $ref: common.yaml#/definitions/mojo_standard_placeholder

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -806,13 +806,8 @@ definitions:
       sku:
         $ref: common.yaml#/definitions/mojo_standard_placeholder
       specification:
-        $comment: json blob of additional data for hardware_product.specification (TO BE RESTRUCTURED SOON)
         oneOf:
-          - $comment: Note that contentSchema is not validated automatically; the data must be json-decoded first and then the schema applied manually
-            type: string
-            contentMediaType: application/json
-            contentSchema:
-              $ref: common.yaml#/definitions/HardwareProductSpecification
+          - $ref: common.yaml#/definitions/HardwareProductSpecification
           - type: 'null'
       rack_unit_size:
         $ref: common.yaml#/definitions/positive_integer

--- a/lib/Conch/Controller/HardwareProduct.pm
+++ b/lib/Conch/Controller/HardwareProduct.pm
@@ -113,17 +113,7 @@ sub create ($c) {
             if not $c->$rs_name->active->search({ id => $input->{$key} })->exists;
     }
 
-    # the specification field is json-encoded (for now); it must be decoded and validated separately
-    if (defined $input->{specification}) {
-        my $new_specification = eval { from_json($input->{specification}) };
-        return $c->status(400, {
-            error => 'request did not match required format',
-            details => [ { path => '/allOf/0/$ref/properties/specification', message => 'Does not match json format.' } ],
-            schema => $c->url_for('/schema/request/HardwareProductCreate'),
-        }) if not defined $new_specification;
-
-        return if not $c->validate_request('HardwareProductSpecification', $new_specification);
-    }
+    $input->{specification} = to_json($input->{specification}) if defined $input->{specification};
 
     my $hardware_product = $c->txn_wrapper(sub ($c) {
         $c->db_hardware_products->create($input);
@@ -166,17 +156,7 @@ sub update ($c) {
             if not $c->$rs_name->active->search({ id => $input->{$key} })->exists;
     }
 
-    # the specification field is json-encoded (for now); it must be decoded and validated separately
-    if (defined $input->{specification}) {
-        my $new_specification = eval { from_json($input->{specification}) };
-        return $c->status(400, {
-            error => 'request did not match required format',
-            details => [ { path => '/allOf/0/$ref/properties/specification', message => 'Does not match json format.' } ],
-            schema => $c->url_for('/schema/request/HardwareProductCreate'),
-        }) if not defined $new_specification;
-
-        return if not $c->validate_request('HardwareProductSpecification', $new_specification);
-    }
+    $input->{specification} = to_json($input->{specification}) if defined $input->{specification};
 
     $c->txn_wrapper(sub ($c) {
         $hardware_product->update({ $input->%*, updated => \'now()' }) if keys $input->%*;

--- a/lib/Conch/DB/Result/HardwareProduct.pm
+++ b/lib/Conch/DB/Result/HardwareProduct.pm
@@ -443,9 +443,25 @@ __PACKAGE__->has_many(
 # Created by DBIx::Class::Schema::Loader v0.07049
 # DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:9Q3v8Ag2aFFkitFegf0t2g
 
+use experimental 'signatures';
+use Mojo::JSON 'from_json';
+
 __PACKAGE__->add_columns(
     '+deactivated' => { is_serializable => 0 },
 );
+
+=head2 TO_JSON
+
+Decode the json-encoded specification field for rendering in responses.
+
+=cut
+
+sub TO_JSON ($self) {
+    my $data = $self->next::method(@_);
+
+    $data->{specification} = from_json($data->{specification}) if defined $data->{specification};
+    return $data;
+}
 
 1;
 __END__


### PR DESCRIPTION
affects endpoints:
- GET /hardware_product/:id_or_name_or_alias_or_sku
- POST /hardware_product
- POST /hardware_product/:id_or_name_or_alias_or_sku

Previously it was json-encoded, but this complicated validating request
payload verification, and also clients will want to render the specification
contents anyway, so just pass them around as inflated structures.

Also note that in api v4.0, this field will be removed entirely.