### PR TITLE
for completing a build, also check phase for devices right in the build

### DIFF
--- a/lib/Conch/Controller/Build.pm
+++ b/lib/Conch/Controller/Build.pm
@@ -206,7 +206,10 @@ sub update ($c) {
 
     return $c->status(409, { error => 'build cannot be completed when it has unhealthy devices' })
         if $input->{completed} and
-            ($build->search_related('devices', { health => { '!=' => 'pass' } })->exists
+            ($build->search_related('devices', {
+                    health => { '!=' => 'pass' },
+                    phase => { '<' => \[ '?::device_phase_enum', 'production' ] },
+                })->exists
              or $build
                 ->related_resultset('racks')
                 ->related_resultset('device_locations')


### PR DESCRIPTION
We were checking device health for both devices on the build and devices located in racks in the build,
but only checking device phase (<= production) for devices located in racks in the build.