### PR TITLE
fix authentication challenge returned on 401, 403 responses

### DIFF
--- a/lib/Conch.pm
+++ b/lib/Conch.pm
@@ -131,7 +131,7 @@ C<< $c->render >> as a side-effect.
         $payload //= { error => 'Unimplemented' } if $code == 501;
 
         # https://tools.ietf.org/html/rfc7235#section-4.1
-        $c->res->headers->www_authenticate('Basic') if $code == 401 or $code == 403;
+        $c->res->headers->www_authenticate('Bearer') if $code == 401 or $code == 403;
 
         $c->res->code($code);
 

--- a/t/integration/users.t
+++ b/t/integration/users.t
@@ -42,7 +42,7 @@ $t->post_ok('/login', json => { email => 'foo@bar.com' })
 
 $t->post_ok('/login', json => { email => 'foo@bar.com', password => 'b' })
     ->status_is(401)
-    ->header_is('WWW-Authenticate', 'Basic')
+    ->header_is('WWW-Authenticate', 'Bearer')
     ->log_debug_is('user lookup for foo@bar.com failed');
 
 my $now = Conch::Time->now;
@@ -173,7 +173,7 @@ subtest 'User' => sub {
 
     $t->post_ok('/user/me', json => { is_admin => JSON::PP::true })
         ->status_is(403)
-        ->header_is('WWW-Authenticate', 'Basic')
+        ->header_is('WWW-Authenticate', 'Bearer')
         ->email_not_sent;
 
     $t->post_ok('/user/me', json => $_)
@@ -238,7 +238,7 @@ subtest 'User' => sub {
 
     $t->get_ok('/user')
         ->status_is(403)
-        ->header_is('WWW-Authenticate', 'Basic')
+        ->header_is('WWW-Authenticate', 'Bearer')
         ->log_debug_is('User must be system admin');
 
     # save cookie for nefarious purposes later on
@@ -291,20 +291,20 @@ subtest 'User' => sub {
 
     $t->get_ok('/user/me')
         ->status_is(401)
-        ->header_is('WWW-Authenticate', 'Basic')
+        ->header_is('WWW-Authenticate', 'Bearer')
         ->log_debug_is('auth failed: no credentials provided');
 
     # "mouhahaha," says the client, "I can pretend to be who I want!"
     my $session_data = { user_id => $super_user->id, expires => time + 3600 };
     $t->get_ok('/user/me', { Cookie => 'conch='.(encode_base64(encode_json($session_data), '') =~ y/=/-/r) })
         ->status_is(401)
-        ->header_is('WWW-Authenticate', 'Basic')
+        ->header_is('WWW-Authenticate', 'Bearer')
         ->log_debug_is('Cookie "conch" is not signed')          # "curses, foiled!"
         ->log_debug_is('auth failed: no credentials provided');
 
     $t->get_ok('/user/me', { Cookie => 'conch='.(encode_base64(encode_json($session_data), '') =~ y/=/-/r).'--'.$signature })
         ->status_is(401)
-        ->header_is('WWW-Authenticate', 'Basic')
+        ->header_is('WWW-Authenticate', 'Bearer')
         ->log_debug_is('Cookie "conch" has bad signature')      # "curses, foiled again!"
         ->log_debug_is('auth failed: no credentials provided');
 
@@ -329,7 +329,7 @@ subtest 'User' => sub {
 
     $t->get_ok('/user/me')
         ->status_is(401)
-        ->header_is('WWW-Authenticate', 'Basic')
+        ->header_is('WWW-Authenticate', 'Bearer')
         ->log_warn_is('user attempting to authenticate with session, but refuse_session_auth is set');
 
     {


### PR DESCRIPTION
We should not be sending "Basic" as we do not recognize that type, but rather "Bearer" where the
Authorization header is expected to contain a JWT.

see https://github.com/joyent/conch-ui/issues/262#issuecomment-707255514