### PR TITLE
fixes for builds and completed state and production phase

### DIFF
--- a/docs/json-schema/query_params.json
+++ b/docs/json-schema/query_params.json
@@ -67,6 +67,21 @@
     "DeactivateUser" : {
       "$ref" : "#/definitions/ChangePassword"
     },
+    "GetBuilds" : {
+      "allOf" : [
+        {
+          "$ref" : "#/definitions/WithDeviceRackData"
+        },
+        {
+          "properties" : {
+            "include_completed" : {
+              "$ref" : "#/definitions/boolean_integer_or_flag"
+            }
+          },
+          "type" : "object"
+        }
+      ]
+    },
     "GetDeviceByAttribute" : {
       "additionalProperties" : {
         "type" : "string"
@@ -210,7 +225,7 @@
       "type" : "object"
     },
     "WithDeviceRackData" : {
-      "additionalProperties" : false,
+      "additionalProperties" : true,
       "properties" : {
         "with_device_health" : {
           "$ref" : "#/definitions/boolean_integer_or_flag"

--- a/docs/modules/Conch::Controller::Build.md
+++ b/docs/modules/Conch::Controller::Build.md
@@ -11,6 +11,9 @@
 If the user is a system admin, retrieve a list of all builds in the database; otherwise,
 limits the list to those build of which the user is a member.
 
+Using optional query parameters, can include counts for device health, device phase and rack phase;
+defaults to returning uncompleted builds only.
+
 Response uses the Builds json schema.
 
 ### create

--- a/docs/modules/Conch::Route::Build.md
+++ b/docs/modules/Conch::Route::Build.md
@@ -21,6 +21,8 @@ Supports the following optional query parameters:
 - `with_device_health` - includes correlated counts of devices having each health value
 - `with_device_phases` - includes correlated counts of devices having each phase value
 - `with_rack_phases` - includes correlated counts of racks having each phase value
+- `include_completed` - also include completed builds (by default, returns uncompleted builds
+only)
 
 - Controller/Action: ["get\_all" in Conch::Controller::Build](../modules/Conch%3A%3AController%3A%3ABuild#get_all)
 - Response: [response.json#/definitions/Builds](../json-schema/response.json#/definitions/Builds)

--- a/json-schema/query_params.yaml
+++ b/json-schema/query_params.yaml
@@ -147,9 +147,16 @@ definitions:
     properties:
       active_minutes:
         $ref: common.yaml#/definitions/non_negative_integer
+  GetBuilds:
+    allOf:
+      - $ref: '#/definitions/WithDeviceRackData'
+      - type: object
+        properties:
+          include_completed:
+            $ref: '#/definitions/boolean_integer_or_flag'
   WithDeviceRackData:
     type: object
-    additionalProperties: false
+    additionalProperties: true  # overlays with other schemas
     properties:
       with_device_health:
         $ref: '#/definitions/boolean_integer_or_flag'

--- a/lib/Conch/Route/Build.pm
+++ b/lib/Conch/Route/Build.pm
@@ -130,6 +130,9 @@ Supports the following optional query parameters:
 
 =item * C<with_rack_phases> - includes correlated counts of racks having each phase value
 
+=item * C<include_completed> - also include completed builds (by default, returns uncompleted builds
+only)
+
 =back
 
 =over 4

--- a/sql/migrations/0173-complete-legacy-builds.sql
+++ b/sql/migrations/0173-complete-legacy-builds.sql
@@ -1,0 +1,34 @@
+SELECT run_migration(173, $$
+
+    -- set all "legacy" builds to completed, using the latest device report timestamp
+    -- as the completed value.
+
+    with mycompleted as (
+        select
+            build.id as build_id,
+            greatest(
+                (select max(dr1.created)
+                    from device device1
+                    left join device_report dr1 on dr1.device_id = device1.id
+                    where device1.build_id = build.id),
+                (select max(dr2.created)
+                    from rack
+                    left join device_location on device_location.rack_id = rack.id
+                    left join device device2 on device2.id = device_location.device_id
+                    left join device_report dr2 on dr2.device_id = device2.id
+                    where rack.build_id = build.id)
+            ) as new_completed
+            from build
+            where started is not null and completed is null
+                and created < '2020-09-17'
+        )
+    update build
+    set completed = mycompleted.new_completed,
+    completed_user_id = case when mycompleted.new_completed is null then null
+        else (select id from user_account where email = 'ether@joyent.com') end
+    from mycompleted
+    where mycompleted.build_id = build.id
+        and started is not null and completed is null
+        and created < '2020-09-17';
+
+$$);

--- a/t/integration/crud/build.t
+++ b/t/integration/crud/build.t
@@ -150,6 +150,17 @@ $t->get_ok('/build/my first build')
     ->json_schema_is('Build')
     ->json_is($build);
 
+$t->get_ok('/build')
+    ->status_is(200)
+    ->json_schema_is('Builds')
+    ->json_is([]);
+
+$t->get_ok('/build?include_completed'.$_)
+    ->status_is(200)
+    ->json_schema_is('Builds')
+    ->json_is([ $build ])
+      foreach ('', '=1');
+
 $t->post_ok('/build/my first build', json => { completed => $now })
     ->status_is(409)
     ->json_is({ error => 'build was already completed' });
@@ -809,7 +820,7 @@ $t->get_ok('/build/our second build/device?active_minutes=5')
     ->json_schema_is('Devices')
     ->json_is($devices);
 
-$t->get_ok('/build?with_device_health&with_device_phases&with_rack_phases')
+$t->get_ok('/build?with_device_health&with_device_phases&with_rack_phases&include_completed')
     ->status_is(200)
     ->json_schema_is('Builds')
     ->json_is([


### PR DESCRIPTION
do not permit adding or creating a device or a rack to/in a completed build

in endpoints:
* POST /build/:build_id_or_name/device
* POST /build/:build_id_or_name/device/:device_id_or_serial_number
* POST /build/:build_id_or_name/rack/:rack_id_or_name
* POST /rack
* POST .../rack/:rack_id_or_name
* POST .../rack/:rack_id_or_name/assignment

closes #1044.

----

add ?include_completed option to GET /build

It defaults to false, so GET /build with no query parameters will return uncompleted
builds only.

closes #1046.

----

Mark all existing builds (with devices that have reported) as "completed"

We use the timestamp on the latest associated device report (for devices
directly in the build, or located in a rack in the build) to determine the
completed time.

closes #1047.

------

do not permit adding device to a build when phase >= production

in endpoints:
* POST /build/:build_id_or_name/device
* POST /build/:build_id_or_name/device/:device_id_or_serial_number
* POST /build/:build_id_or_name/rack/:rack_id_or_name
* POST .../rack/:rack_id_or_name
* POST .../rack/:rack_id_or_name/assignment

closes #1049.