### PR TITLE
simplify data returned by GET /build

### DIFF
--- a/docs/json-schema/query_params.json
+++ b/docs/json-schema/query_params.json
@@ -68,19 +68,29 @@
       "$ref" : "#/definitions/ChangePassword"
     },
     "GetBuilds" : {
-      "allOf" : [
-        {
-          "$ref" : "#/definitions/WithDeviceRackData"
+      "not" : {
+        "completed" : {
+          "const" : 1
         },
-        {
-          "properties" : {
-            "include_completed" : {
-              "$ref" : "#/definitions/boolean_integer_or_flag"
-            }
-          },
-          "type" : "object"
+        "properties" : {
+          "started" : {
+            "const" : 0
+          }
+        },
+        "required" : [
+          "started",
+          "completed"
+        ]
+      },
+      "properties" : {
+        "completed" : {
+          "$ref" : "#/definitions/boolean_integer"
+        },
+        "started" : {
+          "$ref" : "#/definitions/boolean_integer"
         }
-      ]
+      },
+      "type" : "object"
     },
     "GetDeviceByAttribute" : {
       "additionalProperties" : {

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -198,7 +198,64 @@
     },
     "Builds" : {
       "items" : {
-        "$ref" : "#/definitions/Build"
+        "additionalProperties" : false,
+        "properties" : {
+          "completed" : {
+            "oneOf" : [
+              {
+                "type" : "null"
+              },
+              {
+                "format" : "date-time",
+                "type" : "string"
+              }
+            ]
+          },
+          "created" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "description" : {
+            "oneOf" : [
+              {
+                "type" : "null"
+              },
+              {
+                "type" : "string"
+              }
+            ]
+          },
+          "id" : {
+            "$ref" : "common.json#/definitions/uuid"
+          },
+          "links" : {
+            "$ref" : "common.json#/definitions/links"
+          },
+          "name" : {
+            "$ref" : "common.json#/definitions/mojo_standard_placeholder"
+          },
+          "started" : {
+            "oneOf" : [
+              {
+                "type" : "null"
+              },
+              {
+                "format" : "date-time",
+                "type" : "string"
+              }
+            ]
+          }
+        },
+        "required" : [
+          "id",
+          "name",
+          "description",
+          "created",
+          "started",
+          "completed",
+          "links"
+        ],
+        "type" : "object"
       },
       "type" : "array",
       "uniqueItems" : true

--- a/docs/modules/Conch::Controller::Build.md
+++ b/docs/modules/Conch::Controller::Build.md
@@ -12,7 +12,7 @@ If the user is a system admin, retrieve a list of all builds in the database; ot
 limits the list to those build of which the user is a member.
 
 Using optional query parameters, can include counts for device health, device phase and rack phase;
-defaults to returning uncompleted builds only.
+as well as selecting inclusion of unstarted/started, or incomplete/completed builds.
 
 Response uses the Builds json schema.
 

--- a/docs/modules/Conch::Route::Build.md
+++ b/docs/modules/Conch::Route::Build.md
@@ -18,11 +18,8 @@ All routes require authentication.
 
 Supports the following optional query parameters:
 
-- `with_device_health` - includes correlated counts of devices having each health value
-- `with_device_phases` - includes correlated counts of devices having each phase value
-- `with_rack_phases` - includes correlated counts of racks having each phase value
-- `include_completed` - also include completed builds (by default, returns uncompleted builds
-only)
+- `started=<0|1>` only return unstarted, or started, builds respectively
+- `completed=<0|1>` only return incomplete, or complete, builds respectively
 
 - Controller/Action: ["get\_all" in Conch::Controller::Build](../modules/Conch%3A%3AController%3A%3ABuild#get_all)
 - Response: [response.json#/definitions/Builds](../json-schema/response.json#/definitions/Builds)

--- a/json-schema/query_params.yaml
+++ b/json-schema/query_params.yaml
@@ -148,12 +148,21 @@ definitions:
       active_minutes:
         $ref: common.yaml#/definitions/non_negative_integer
   GetBuilds:
-    allOf:
-      - $ref: '#/definitions/WithDeviceRackData'
-      - type: object
-        properties:
-          include_completed:
-            $ref: '#/definitions/boolean_integer_or_flag'
+    type: object
+    properties:
+      started:
+        $ref: '#/definitions/boolean_integer'
+      completed:
+        $ref: '#/definitions/boolean_integer'
+    not:
+      required:
+        - started
+        - completed
+      properties:
+        started:
+          const: 0
+      completed:
+          const: 1
   WithDeviceRackData:
     type: object
     additionalProperties: true  # overlays with other schemas

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -2056,7 +2056,40 @@ definitions:
     type: array
     uniqueItems: true
     items:
-      $ref: '#/definitions/Build'
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - description
+        - created
+        - started
+        - completed
+        - links
+      properties:
+        id:
+          $ref: common.yaml#/definitions/uuid
+        name:
+          $ref: common.yaml#/definitions/mojo_standard_placeholder
+        description:
+          oneOf:
+            - type: 'null'
+            - type: string
+        created:
+          type: string
+          format: date-time
+        started:
+          oneOf:
+            - type: 'null'
+            - type: string
+              format: date-time
+        completed:
+          oneOf:
+            - type: 'null'
+            - type: string
+              format: date-time
+        links:
+          $ref: common.yaml#/definitions/links
   BuildUsers:
     type: array
     uniqueItems: true

--- a/lib/Conch/Route/Build.pm
+++ b/lib/Conch/Route/Build.pm
@@ -124,14 +124,9 @@ Supports the following optional query parameters:
 
 =over 4
 
-=item * C<with_device_health> - includes correlated counts of devices having each health value
+=item * C<< started=<0|1> >> only return unstarted, or started, builds respectively
 
-=item * C<with_device_phases> - includes correlated counts of devices having each phase value
-
-=item * C<with_rack_phases> - includes correlated counts of racks having each phase value
-
-=item * C<include_completed> - also include completed builds (by default, returns uncompleted builds
-only)
+=item * C<< completed=<0|1> >> only return incomplete, or complete, builds respectively
 
 =back
 

--- a/t/pod-spelling.t
+++ b/t/pod-spelling.t
@@ -71,6 +71,7 @@ subtest
 subworkspace
 timestamptz
 TODO
+unstarted
 validator
 VLAN
 workspace


### PR DESCRIPTION
- remove options ?with_device_health, ?with_device_phases, ?with_rack_phases
- remove 'completed_user' and 'admins' properties
- replace ?include_completed option with ?started=<0|1> and ?completed=<0|1>
for filtering results (by default, all builds are returned)