### PR TITLE
deprecate legacy validation endpoints

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -101,7 +101,11 @@ Available top-level routes are:
 
 * [Conch::Route::Validation](modules/Conch::Route::Validation)
   * `/validation`
+
+* [Conch::Route::ValidationPlan](modules/Conch::Route::ValidationPlan)
   * `/validation_plan`
+
+* [Conch::Route::ValidationState](modules/Conch::Route::ValidationState)
   * `/validation_state`
 
 * [Conch::Route::Workspace](modules/Conch::Route::Workspace)

--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -688,7 +688,13 @@
           "type" : "integer"
         },
         "validation_plan_id" : {
-          "$ref" : "common.json#/definitions/uuid"
+          "$comment" : "this property will become nullable in v3.3 and removed in v4.0",
+          "allOf" : [
+            {
+              "$ref" : "common.json#/definitions/uuid"
+            }
+          ],
+          "deprecated" : true
         }
       },
       "type" : "object"

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -2575,7 +2575,13 @@
           "$ref" : "common.json#/definitions/validation_status"
         },
         "validation_plan_id" : {
-          "$ref" : "common.json#/definitions/uuid"
+          "$comment" : "this property will be removed in v3.1",
+          "allOf" : [
+            {
+              "$ref" : "common.json#/definitions/uuid"
+            }
+          ],
+          "deprecated" : true
         }
       },
       "required" : [
@@ -3073,7 +3079,13 @@
           "$ref" : "common.json#/definitions/validation_status"
         },
         "validation_plan_id" : {
-          "$ref" : "common.json#/definitions/uuid"
+          "$comment" : "this property will be removed in v3.1",
+          "allOf" : [
+            {
+              "$ref" : "common.json#/definitions/uuid"
+            }
+          ],
+          "deprecated" : true
         }
       },
       "required" : [

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -1824,6 +1824,59 @@
       ],
       "type" : "object"
     },
+    "LegacyValidation" : {
+      "additionalProperties" : false,
+      "properties" : {
+        "created" : {
+          "format" : "date-time",
+          "type" : "string"
+        },
+        "deactivated" : {
+          "oneOf" : [
+            {
+              "type" : "null"
+            },
+            {
+              "format" : "date-time",
+              "type" : "string"
+            }
+          ]
+        },
+        "description" : {
+          "type" : "string"
+        },
+        "id" : {
+          "$ref" : "common.json#/definitions/uuid"
+        },
+        "name" : {
+          "$ref" : "common.json#/definitions/mojo_standard_placeholder"
+        },
+        "updated" : {
+          "format" : "date-time",
+          "type" : "string"
+        },
+        "version" : {
+          "$ref" : "common.json#/definitions/positive_integer"
+        }
+      },
+      "required" : [
+        "id",
+        "name",
+        "version",
+        "description",
+        "created",
+        "updated",
+        "deactivated"
+      ],
+      "type" : "object"
+    },
+    "LegacyValidations" : {
+      "items" : {
+        "$ref" : "#/definitions/LegacyValidation"
+      },
+      "type" : "array",
+      "uniqueItems" : true
+    },
     "LoginToken" : {
       "additionalProperties" : false,
       "properties" : {
@@ -2847,52 +2900,6 @@
       "type" : "array",
       "uniqueItems" : true
     },
-    "Validation" : {
-      "additionalProperties" : false,
-      "properties" : {
-        "created" : {
-          "format" : "date-time",
-          "type" : "string"
-        },
-        "deactivated" : {
-          "oneOf" : [
-            {
-              "type" : "null"
-            },
-            {
-              "format" : "date-time",
-              "type" : "string"
-            }
-          ]
-        },
-        "description" : {
-          "type" : "string"
-        },
-        "id" : {
-          "$ref" : "common.json#/definitions/uuid"
-        },
-        "name" : {
-          "$ref" : "common.json#/definitions/mojo_standard_placeholder"
-        },
-        "updated" : {
-          "format" : "date-time",
-          "type" : "string"
-        },
-        "version" : {
-          "$ref" : "common.json#/definitions/positive_integer"
-        }
-      },
-      "required" : [
-        "id",
-        "name",
-        "version",
-        "description",
-        "created",
-        "updated",
-        "deactivated"
-      ],
-      "type" : "object"
-    },
     "ValidationError" : {
       "additionalProperties" : false,
       "description" : "base structure for all query_param, request, response validation error responses",
@@ -3074,13 +3081,6 @@
         "device_report_id"
       ],
       "type" : "object"
-    },
-    "Validations" : {
-      "items" : {
-        "$ref" : "#/definitions/Validation"
-      },
-      "type" : "array",
-      "uniqueItems" : true
     },
     "Version" : {
       "additionalProperties" : false,

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -1678,7 +1678,13 @@
           "type" : "integer"
         },
         "validation_plan_id" : {
-          "$ref" : "common.json#/definitions/uuid"
+          "$comment" : "this property will become nullable in v3.3 and removed in v4.0",
+          "allOf" : [
+            {
+              "$ref" : "common.json#/definitions/uuid"
+            }
+          ],
+          "deprecated" : true
         }
       },
       "required" : [

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -1831,7 +1831,9 @@
       "type" : "object"
     },
     "LegacyValidation" : {
+      "$comment" : "this definition will be removed in v4.0",
       "additionalProperties" : false,
+      "deprecated" : true,
       "properties" : {
         "created" : {
           "format" : "date-time",
@@ -1876,7 +1878,45 @@
       ],
       "type" : "object"
     },
+    "LegacyValidationPlan" : {
+      "$comment" : "this definition will be removed in v4.0",
+      "additionalProperties" : false,
+      "deprecated" : true,
+      "properties" : {
+        "created" : {
+          "format" : "date-time",
+          "type" : "string"
+        },
+        "description" : {
+          "type" : "string"
+        },
+        "id" : {
+          "$ref" : "common.json#/definitions/uuid"
+        },
+        "name" : {
+          "$ref" : "common.json#/definitions/mojo_standard_placeholder"
+        }
+      },
+      "required" : [
+        "id",
+        "name",
+        "description",
+        "created"
+      ],
+      "type" : "object"
+    },
+    "LegacyValidationPlans" : {
+      "$comment" : "this definition will be removed in v4.0",
+      "deprecated" : true,
+      "items" : {
+        "$ref" : "#/definitions/LegacyValidationPlan"
+      },
+      "type" : "array",
+      "uniqueItems" : true
+    },
     "LegacyValidations" : {
+      "$comment" : "this definition will be removed in v4.0",
+      "deprecated" : true,
       "items" : {
         "$ref" : "#/definitions/LegacyValidation"
       },
@@ -2943,38 +2983,6 @@
         "schema"
       ],
       "type" : "object"
-    },
-    "ValidationPlan" : {
-      "additionalProperties" : false,
-      "properties" : {
-        "created" : {
-          "format" : "date-time",
-          "type" : "string"
-        },
-        "description" : {
-          "type" : "string"
-        },
-        "id" : {
-          "$ref" : "common.json#/definitions/uuid"
-        },
-        "name" : {
-          "$ref" : "common.json#/definitions/mojo_standard_placeholder"
-        }
-      },
-      "required" : [
-        "id",
-        "name",
-        "description",
-        "created"
-      ],
-      "type" : "object"
-    },
-    "ValidationPlans" : {
-      "items" : {
-        "$ref" : "#/definitions/ValidationPlan"
-      },
-      "type" : "array",
-      "uniqueItems" : true
     },
     "ValidationResult" : {
       "additionalProperties" : false,

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -1914,6 +1914,79 @@
       "type" : "array",
       "uniqueItems" : true
     },
+    "LegacyValidationResult" : {
+      "additionalProperties" : false,
+      "properties" : {
+        "category" : {
+          "type" : "string"
+        },
+        "component" : {
+          "oneOf" : [
+            {
+              "type" : "null"
+            },
+            {
+              "type" : "string"
+            }
+          ]
+        },
+        "description" : {
+          "type" : "string"
+        },
+        "hint" : {
+          "oneOf" : [
+            {
+              "type" : "null"
+            },
+            {
+              "type" : "string"
+            }
+          ]
+        },
+        "id" : {
+          "oneOf" : [
+            {
+              "type" : "null"
+            },
+            {
+              "$ref" : "common.json#/definitions/uuid"
+            }
+          ]
+        },
+        "message" : {
+          "type" : "string"
+        },
+        "name" : {
+          "$ref" : "common.json#/definitions/mojo_standard_placeholder"
+        },
+        "status" : {
+          "$ref" : "common.json#/definitions/validation_status"
+        },
+        "validation_id" : {
+          "$ref" : "common.json#/definitions/uuid"
+        },
+        "version" : {
+          "$ref" : "common.json#/definitions/positive_integer"
+        }
+      },
+      "required" : [
+        "id",
+        "category",
+        "component",
+        "hint",
+        "message",
+        "status",
+        "validation_id"
+      ],
+      "type" : "object"
+    },
+    "LegacyValidationResults" : {
+      "items" : {
+        "$ref" : "#/definitions/LegacyValidationResult"
+      },
+      "type" : "array",
+      "uniqueItems" : true
+    },
     "LegacyValidations" : {
       "$comment" : "this definition will be removed in v4.0",
       "deprecated" : true,
@@ -2606,7 +2679,7 @@
           "$ref" : "common.json#/definitions/uuid"
         },
         "results" : {
-          "$ref" : "#/definitions/ValidationResults"
+          "$ref" : "#/definitions/LegacyValidationResults"
         },
         "sku" : {
           "$ref" : "common.json#/definitions/mojo_standard_placeholder"
@@ -2984,79 +3057,6 @@
       ],
       "type" : "object"
     },
-    "ValidationResult" : {
-      "additionalProperties" : false,
-      "properties" : {
-        "category" : {
-          "type" : "string"
-        },
-        "component" : {
-          "oneOf" : [
-            {
-              "type" : "null"
-            },
-            {
-              "type" : "string"
-            }
-          ]
-        },
-        "description" : {
-          "type" : "string"
-        },
-        "hint" : {
-          "oneOf" : [
-            {
-              "type" : "null"
-            },
-            {
-              "type" : "string"
-            }
-          ]
-        },
-        "id" : {
-          "oneOf" : [
-            {
-              "type" : "null"
-            },
-            {
-              "$ref" : "common.json#/definitions/uuid"
-            }
-          ]
-        },
-        "message" : {
-          "type" : "string"
-        },
-        "name" : {
-          "$ref" : "common.json#/definitions/mojo_standard_placeholder"
-        },
-        "status" : {
-          "$ref" : "common.json#/definitions/validation_status"
-        },
-        "validation_id" : {
-          "$ref" : "common.json#/definitions/uuid"
-        },
-        "version" : {
-          "$ref" : "common.json#/definitions/positive_integer"
-        }
-      },
-      "required" : [
-        "id",
-        "category",
-        "component",
-        "hint",
-        "message",
-        "status",
-        "validation_id"
-      ],
-      "type" : "object"
-    },
-    "ValidationResults" : {
-      "items" : {
-        "$ref" : "#/definitions/ValidationResult"
-      },
-      "type" : "array",
-      "uniqueItems" : true
-    },
     "ValidationStateWithResults" : {
       "additionalProperties" : false,
       "properties" : {
@@ -3078,7 +3078,7 @@
         },
         "results" : {
           "items" : {
-            "$ref" : "#/definitions/ValidationResult"
+            "$ref" : "#/definitions/LegacyValidationResult"
           },
           "type" : "array",
           "uniqueItems" : true

--- a/docs/modules/Conch::Controller::DeviceValidation.md
+++ b/docs/modules/Conch::Controller::DeviceValidation.md
@@ -23,7 +23,7 @@ Validate the device against the specified validation.
 
 This is useful for testing and evaluating experimental validations against a given device.
 
-Response uses the ValidationResults json schema.
+Response uses the LegacyValidationResults json schema.
 
 ### run\_validation\_plan
 
@@ -34,7 +34,7 @@ Validate the device against the specified Validation Plan.
 This is useful for testing and evaluating Validation Plans against a given
 device.
 
-Response uses the ValidationResults json schema.
+Response uses the LegacyValidationResults json schema.
 
 ## LICENSING
 

--- a/docs/modules/Conch::Controller::Validation.md
+++ b/docs/modules/Conch::Controller::Validation.md
@@ -12,11 +12,11 @@ Controller for managing Validations, **NOT** executing them.
 
 List all Validations.
 
-Response uses the Validations json schema (including deactivated ones).
+Response uses the LegacyValidations json schema (including deactivated ones).
 
 ### find\_validation
 
-Chainable action that uses the `validation_id_or_name` value provided in the stash (usually
+Chainable action that uses the `legacy_validation_id_or_name` value provided in the stash (usually
 via the request URL) to look up a validation, and stashes the query to get to it in
 `validation_rs`.
 
@@ -24,7 +24,7 @@ via the request URL) to look up a validation, and stashes the query to get to it
 
 Get the Validation specified by uuid or name.
 
-Response uses the Validation json schema.
+Response uses the LegacyValidation json schema.
 
 ## LICENSING
 

--- a/docs/modules/Conch::Controller::ValidationPlan.md
+++ b/docs/modules/Conch::Controller::ValidationPlan.md
@@ -30,7 +30,7 @@ Response uses the ValidationPlan json schema.
 
 List all Validations associated with the Validation Plan, both active and deactivated.
 
-Response uses the Validations json schema.
+Response uses the LegacyValidations json schema.
 
 ## LICENSING
 

--- a/docs/modules/Conch::Controller::ValidationPlan.md
+++ b/docs/modules/Conch::Controller::ValidationPlan.md
@@ -12,19 +12,19 @@ Controller for managing Validation Plans
 
 List all available Validation Plans.
 
-Response uses the ValidationPlans json schema.
+Response uses the LegacyValidationPlans json schema.
 
 ### find\_validation\_plan
 
-Chainable action that uses the `validation_plan_id_or_name` provided in the stash
+Chainable action that uses the `legacy_validation_plan_id_or_name` provided in the stash
 (usually via the request URL) to look up a validation\_plan, and stashes the result in
-`validation_plan`.
+`legacy_validation_plan`.
 
 ### get
 
 Get the (active) Validation Plan specified by uuid or name.
 
-Response uses the ValidationPlan json schema.
+Response uses the LegacyValidationPlan json schema.
 
 ### get\_validations
 

--- a/docs/modules/Conch::Controller::ValidationPlan.md
+++ b/docs/modules/Conch::Controller::ValidationPlan.md
@@ -1,4 +1,4 @@
-# Conch::Controller::Validation
+# Conch::Controller::ValidationPlan
 
 ## SOURCE
 

--- a/docs/modules/Conch::Route.md
+++ b/docs/modules/Conch::Route.md
@@ -124,9 +124,17 @@ See ["unsecured\_routes" in Conch::Route::JSONSchema](../modules/Conch%3A%3ARout
 
 See ["routes" in Conch::Route::User](../modules/Conch%3A%3ARoute%3A%3AUser#routes)
 
-### `* /validation`, `* /validation_plan`, `* /validation_state`
+### `* /validation`
 
 See ["routes" in Conch::Route::Validation](../modules/Conch%3A%3ARoute%3A%3AValidation#routes)
+
+### `* /validation_plan`
+
+See ["routes" in Conch::Route::ValidationPlan](../modules/Conch%3A%3ARoute%3A%3AValidationPlan#routes)
+
+### `* /validation_state`
+
+See ["routes" in Conch::Route::ValidationState](../modules/Conch%3A%3ARoute%3A%3AValidationState#routes)
 
 ### `* /workspace`
 

--- a/docs/modules/Conch::Route::Device.md
+++ b/docs/modules/Conch::Route::Device.md
@@ -177,7 +177,7 @@ This endpoint is **deprecated** and will be removed in Conch API v4.0.
 - User requires the read-only role
 - Controller/Action: ["validate" in Conch::Controller::DeviceValidation](../modules/Conch%3A%3AController%3A%3ADeviceValidation#validate)
 - Request: [request.json#/definitions/DeviceReport](../json-schema/request.json#/definitions/DeviceReport)
-- Response: [response.json#/definitions/ValidationResults](../json-schema/response.json#/definitions/ValidationResults)
+- Response: [response.json#/definitions/LegacyValidationResults](../json-schema/response.json#/definitions/LegacyValidationResults)
 
 ### `POST /device/:device_id_or_serial_number/validation_plan/:validation_plan_id`
 
@@ -188,7 +188,7 @@ This endpoint is **deprecated** and will be removed in Conch API v4.0.
 - User requires the read-only role
 - Controller/Action: ["run\_validation\_plan" in Conch::Controller::DeviceValidation](../modules/Conch%3A%3AController%3A%3ADeviceValidation#run_validation_plan)
 - Request: [request.json#/definitions/DeviceReport](../json-schema/request.json#/definitions/DeviceReport)
-- Response: [response.json#/definitions/ValidationResults](../json-schema/response.json#/definitions/ValidationResults)
+- Response: [response.json#/definitions/LegacyValidationResults](../json-schema/response.json#/definitions/LegacyValidationResults)
 
 ### `GET /device/:device_id_or_serial_number/validation_state?status=<pass|fail|error>&status=...`
 

--- a/docs/modules/Conch::Route::Device.md
+++ b/docs/modules/Conch::Route::Device.md
@@ -172,6 +172,8 @@ otherwise.
 
 Does not store validation results.
 
+This endpoint is **deprecated** and will be removed in Conch API v4.0.
+
 - User requires the read-only role
 - Controller/Action: ["validate" in Conch::Controller::DeviceValidation](../modules/Conch%3A%3AController%3A%3ADeviceValidation#validate)
 - Request: [request.json#/definitions/DeviceReport](../json-schema/request.json#/definitions/DeviceReport)
@@ -180,6 +182,8 @@ Does not store validation results.
 ### `POST /device/:device_id_or_serial_number/validation_plan/:validation_plan_id`
 
 Does not store validation results.
+
+This endpoint is **deprecated** and will be removed in Conch API v4.0.
 
 - User requires the read-only role
 - Controller/Action: ["run\_validation\_plan" in Conch::Controller::DeviceValidation](../modules/Conch%3A%3AController%3A%3ADeviceValidation#run_validation_plan)

--- a/docs/modules/Conch::Route::Validation.md
+++ b/docs/modules/Conch::Route::Validation.md
@@ -8,7 +8,7 @@
 
 ### routes
 
-Sets up the routes for /validation, /validation\_plan and /validation\_state.
+Sets up the routes for /validation.
 
 ## ROUTE ENDPOINTS
 
@@ -23,26 +23,6 @@ All routes require authentication.
 
 - Controller/Action: ["get" in Conch::Controller::Validation](../modules/Conch%3A%3AController%3A%3AValidation#get)
 - Response: [response.json#/definitions/Validation](../json-schema/response.json#/definitions/Validation)
-
-### `GET /validation_plan`
-
-- Controller/Action: ["get\_all" in Conch::Controller::ValidationPlan](../modules/Conch%3A%3AController%3A%3AValidationPlan#get_all)
-- Response: [response.json#/definitions/ValidationPlans](../json-schema/response.json#/definitions/ValidationPlans)
-
-### `GET /validation_plan/:validation_plan_id_or_name`
-
-- Controller/Action: ["get" in Conch::Controller::ValidationPlan](../modules/Conch%3A%3AController%3A%3AValidationPlan#get)
-- Response: [response.json#/definitions/ValidationPlan](../json-schema/response.json#/definitions/ValidationPlan)
-
-### `GET /validation_plan/:validation_plan_id_or_name/validation`
-
-- Controller/Action: ["validations" in Conch::Controller::ValidationPlan](../modules/Conch%3A%3AController%3A%3AValidationPlan#validations)
-- Response: [response.json#/definitions/Validations](../json-schema/response.json#/definitions/Validations)
-
-### `GET /validation_state/:validation_state_id`
-
-- Controller/Action: ["get" in Conch::Controller::ValidationState](../modules/Conch%3A%3AController%3A%3AValidationState#get)
-- Response: [response.json#/definitions/ValidationStateWithResults](../json-schema/response.json#/definitions/ValidationStateWithResults)
 
 ## LICENSING
 

--- a/docs/modules/Conch::Route::Validation.md
+++ b/docs/modules/Conch::Route::Validation.md
@@ -10,6 +10,8 @@
 
 Sets up the routes for /validation.
 
+All routes are **deprecated** and will be removed in Conch API v3.1.
+
 ## ROUTE ENDPOINTS
 
 All routes require authentication.
@@ -17,12 +19,12 @@ All routes require authentication.
 ### `GET /validation`
 
 - Controller/Action: ["get\_all" in Conch::Controller::Validation](../modules/Conch%3A%3AController%3A%3AValidation#get_all)
-- Response: [response.json#/definitions/Validations](../json-schema/response.json#/definitions/Validations)
+- Response: [response.json#/definitions/LegacyValidations](../json-schema/response.json#/definitions/LegacyValidations)
 
-### `GET /validation/:validation_id_or_name`
+### `GET /validation/:legacy_validation_id_or_name`
 
 - Controller/Action: ["get" in Conch::Controller::Validation](../modules/Conch%3A%3AController%3A%3AValidation#get)
-- Response: [response.json#/definitions/Validation](../json-schema/response.json#/definitions/Validation)
+- Response: [response.json#/definitions/LegacyValidation](../json-schema/response.json#/definitions/LegacyValidation)
 
 ## LICENSING
 

--- a/docs/modules/Conch::Route::ValidationPlan.md
+++ b/docs/modules/Conch::Route::ValidationPlan.md
@@ -10,6 +10,8 @@
 
 Sets up the routes for /validation\_plan.
 
+All routes are **deprecated** and will be removed in Conch API v4.0.
+
 ## ROUTE ENDPOINTS
 
 All routes require authentication.
@@ -17,14 +19,14 @@ All routes require authentication.
 ### `GET /validation_plan`
 
 - Controller/Action: ["get\_all" in Conch::Controller::ValidationPlan](../modules/Conch%3A%3AController%3A%3AValidationPlan#get_all)
-- Response: [response.json#/definitions/ValidationPlans](../json-schema/response.json#/definitions/ValidationPlans)
+- Response: [response.json#/definitions/LegacyValidationPlans](../json-schema/response.json#/definitions/LegacyValidationPlans)
 
-### `GET /validation_plan/:validation_plan_id_or_name`
+### `GET /validation_plan/:legacy_validation_plan_id_or_name`
 
 - Controller/Action: ["get" in Conch::Controller::ValidationPlan](../modules/Conch%3A%3AController%3A%3AValidationPlan#get)
-- Response: [response.json#/definitions/ValidationPlan](../json-schema/response.json#/definitions/ValidationPlan)
+- Response: [response.json#/definitions/LegacyValidationPlan](../json-schema/response.json#/definitions/LegacyValidationPlan)
 
-### `GET /validation_plan/:validation_plan_id_or_name/validation`
+### `GET /validation_plan/:legacy_validation_plan_id_or_name/validation`
 
 - Controller/Action: ["validations" in Conch::Controller::ValidationPlan](../modules/Conch%3A%3AController%3A%3AValidationPlan#validations)
 - Response: [response.json#/definitions/LegacyValidations](../json-schema/response.json#/definitions/LegacyValidations)

--- a/docs/modules/Conch::Route::ValidationPlan.md
+++ b/docs/modules/Conch::Route::ValidationPlan.md
@@ -27,7 +27,7 @@ All routes require authentication.
 ### `GET /validation_plan/:validation_plan_id_or_name/validation`
 
 - Controller/Action: ["validations" in Conch::Controller::ValidationPlan](../modules/Conch%3A%3AController%3A%3AValidationPlan#validations)
-- Response: [response.json#/definitions/Validations](../json-schema/response.json#/definitions/Validations)
+- Response: [response.json#/definitions/LegacyValidations](../json-schema/response.json#/definitions/LegacyValidations)
 
 ## LICENSING
 

--- a/docs/modules/Conch::Route::ValidationPlan.md
+++ b/docs/modules/Conch::Route::ValidationPlan.md
@@ -1,0 +1,38 @@
+# Conch::Route::ValidationPlan
+
+## SOURCE
+
+[https://github.com/joyent/conch-api/blob/master/lib/Conch/Route/ValidationPlan.pm](https://github.com/joyent/conch-api/blob/master/lib/Conch/Route/ValidationPlan.pm)
+
+## METHODS
+
+### routes
+
+Sets up the routes for /validation\_plan.
+
+## ROUTE ENDPOINTS
+
+All routes require authentication.
+
+### `GET /validation_plan`
+
+- Controller/Action: ["get\_all" in Conch::Controller::ValidationPlan](../modules/Conch%3A%3AController%3A%3AValidationPlan#get_all)
+- Response: [response.json#/definitions/ValidationPlans](../json-schema/response.json#/definitions/ValidationPlans)
+
+### `GET /validation_plan/:validation_plan_id_or_name`
+
+- Controller/Action: ["get" in Conch::Controller::ValidationPlan](../modules/Conch%3A%3AController%3A%3AValidationPlan#get)
+- Response: [response.json#/definitions/ValidationPlan](../json-schema/response.json#/definitions/ValidationPlan)
+
+### `GET /validation_plan/:validation_plan_id_or_name/validation`
+
+- Controller/Action: ["validations" in Conch::Controller::ValidationPlan](../modules/Conch%3A%3AController%3A%3AValidationPlan#validations)
+- Response: [response.json#/definitions/Validations](../json-schema/response.json#/definitions/Validations)
+
+## LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at [https://www.mozilla.org/en-US/MPL/2.0/](https://www.mozilla.org/en-US/MPL/2.0/).

--- a/docs/modules/Conch::Route::ValidationState.md
+++ b/docs/modules/Conch::Route::ValidationState.md
@@ -1,0 +1,28 @@
+# Conch::Route::ValidationState
+
+## SOURCE
+
+[https://github.com/joyent/conch-api/blob/master/lib/Conch/Route/ValidationState.pm](https://github.com/joyent/conch-api/blob/master/lib/Conch/Route/ValidationState.pm)
+
+## METHODS
+
+### routes
+
+Sets up the routes for /validation\_state.
+
+## ROUTE ENDPOINTS
+
+All routes require authentication.
+
+### `GET /validation_state/:validation_state_id`
+
+- Controller/Action: ["get" in Conch::Controller::ValidationState](../modules/Conch%3A%3AController%3A%3AValidationState#get)
+- Response: [response.json#/definitions/ValidationStateWithResults](../json-schema/response.json#/definitions/ValidationStateWithResults)
+
+## LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at [https://www.mozilla.org/en-US/MPL/2.0/](https://www.mozilla.org/en-US/MPL/2.0/).

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -127,6 +127,8 @@
 * [Conch::Route::Relay](../modules/Conch::Route::Relay)
 * [Conch::Route::User](../modules/Conch::Route::User)
 * [Conch::Route::Validation](../modules/Conch::Route::Validation)
+* [Conch::Route::ValidationPlan](../modules/Conch::Route::ValidationPlan)
+* [Conch::Route::ValidationState](../modules/Conch::Route::ValidationState)
 * [Conch::Route::Workspace](../modules/Conch::Route::Workspace)
 * [Conch::Time](../modules/Conch::Time)
 * [Conch::UUID](../modules/Conch::UUID)

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -294,7 +294,10 @@ definitions:
       rack_unit_size:
         $ref: common.yaml#/definitions/positive_integer
       validation_plan_id:
-        $ref: common.yaml#/definitions/uuid
+        $comment: this property will become nullable in v3.3 and removed in v4.0
+        deprecated: true
+        allOf:
+          - $ref: common.yaml#/definitions/uuid
       purpose:
         type: string
       bios_firmware:

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -929,12 +929,12 @@ definitions:
                 - $ref: common.yaml#/definitions/device_health
             additionalProperties:
               $ref: common.yaml#/definitions/positive_integer
-  Validations:
+  LegacyValidations:
     type: array
     uniqueItems: true
     items:
-      $ref: '#/definitions/Validation'
-  Validation:
+      $ref: '#/definitions/LegacyValidation'
+  LegacyValidation:
     type: object
     additionalProperties: false
     required:

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -816,7 +816,10 @@ definitions:
         type: string
         format: date-time
       validation_plan_id:
-        $ref: common.yaml#/definitions/uuid
+        $comment: this property will become nullable in v3.3 and removed in v4.0
+        deprecated: true
+        allOf:
+          - $ref: common.yaml#/definitions/uuid
       bios_firmware:
         type: string
       cpu_num:

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -999,7 +999,7 @@ definitions:
       created:
         type: string
         format: date-time
-  ValidationResult:
+  LegacyValidationResult:
     type: object
     additionalProperties: false
     required:
@@ -1037,11 +1037,11 @@ definitions:
         $ref: common.yaml#/definitions/positive_integer
       description:
         type: string
-  ValidationResults:
+  LegacyValidationResults:
     type: array
     uniqueItems: true
     items:
-      $ref: '#/definitions/ValidationResult'
+      $ref: '#/definitions/LegacyValidationResult'
   ValidationStateWithResults:
     type: object
     additionalProperties: false
@@ -1066,7 +1066,7 @@ definitions:
         type: array
         uniqueItems: true
         items:
-          $ref: '#/definitions/ValidationResult'
+          $ref: '#/definitions/LegacyValidationResult'
       status:
         $ref: common.yaml#/definitions/validation_status
       validation_plan_id:
@@ -1103,7 +1103,7 @@ definitions:
       status:
         $ref: common.yaml#/definitions/validation_status
       results:
-        $ref: '#/definitions/ValidationResults'
+        $ref: '#/definitions/LegacyValidationResults'
   WorkspaceRelays:
     deprecated: true
     type: array

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -1062,7 +1062,10 @@ definitions:
       status:
         $ref: common.yaml#/definitions/validation_status
       validation_plan_id:
-        $ref: common.yaml#/definitions/uuid
+        $comment: this property will be removed in v3.1
+        deprecated: true
+        allOf:
+          - $ref: common.yaml#/definitions/uuid
       hardware_product_id:
         $ref: common.yaml#/definitions/uuid
       device_report_id:
@@ -1081,7 +1084,10 @@ definitions:
       device_serial_number:
         $ref: common.yaml#/definitions/device_serial_number
       validation_plan_id:
-        $ref: common.yaml#/definitions/uuid
+        $comment: this property will be removed in v3.1
+        deprecated: true
+        allOf:
+          - $ref: common.yaml#/definitions/uuid
       hardware_product_id:
         $ref: common.yaml#/definitions/uuid
       sku:

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -933,11 +933,15 @@ definitions:
             additionalProperties:
               $ref: common.yaml#/definitions/positive_integer
   LegacyValidations:
+    $comment: this definition will be removed in v4.0
+    deprecated: true
     type: array
     uniqueItems: true
     items:
       $ref: '#/definitions/LegacyValidation'
   LegacyValidation:
+    $comment: this definition will be removed in v4.0
+    deprecated: true
     type: object
     additionalProperties: false
     required:
@@ -968,12 +972,16 @@ definitions:
           - type: 'null'
           - type: string
             format: date-time
-  ValidationPlans:
+  LegacyValidationPlans:
+    $comment: this definition will be removed in v4.0
+    deprecated: true
     type: array
     uniqueItems: true
     items:
-      $ref: '#/definitions/ValidationPlan'
-  ValidationPlan:
+      $ref: '#/definitions/LegacyValidationPlan'
+  LegacyValidationPlan:
+    $comment: this definition will be removed in v4.0
+    deprecated: true
     type: object
     additionalProperties: false
     required:

--- a/lib/Conch/Controller/DeviceValidation.pm
+++ b/lib/Conch/Controller/DeviceValidation.pm
@@ -52,7 +52,7 @@ B<DOES NOT STORE VALIDATION RESULTS>.
 
 This is useful for testing and evaluating experimental validations against a given device.
 
-Response uses the ValidationResults json schema.
+Response uses the LegacyValidationResults json schema.
 
 =cut
 
@@ -91,7 +91,7 @@ B<DOES NOT STORE VALIDATION RESULTS>.
 This is useful for testing and evaluating Validation Plans against a given
 device.
 
-Response uses the ValidationResults json schema.
+Response uses the LegacyValidationResults json schema.
 
 =cut
 

--- a/lib/Conch/Controller/Validation.pm
+++ b/lib/Conch/Controller/Validation.pm
@@ -18,7 +18,7 @@ Controller for managing Validations, B<NOT> executing them.
 
 List all Validations.
 
-Response uses the Validations json schema (including deactivated ones).
+Response uses the LegacyValidations json schema (including deactivated ones).
 
 =cut
 
@@ -29,14 +29,14 @@ sub get_all ($c) {
 
 =head2 find_validation
 
-Chainable action that uses the C<validation_id_or_name> value provided in the stash (usually
+Chainable action that uses the C<legacy_validation_id_or_name> value provided in the stash (usually
 via the request URL) to look up a validation, and stashes the query to get to it in
 C<validation_rs>.
 
 =cut
 
 sub find_validation($c) {
-    my $identifier = $c->stash('validation_id_or_name');
+    my $identifier = $c->stash('legacy_validation_id_or_name');
 
     my $validation_rs = $c->db_validations->search({
         (is_uuid($identifier) ? 'id' : 'name') => $identifier,
@@ -55,7 +55,7 @@ sub find_validation($c) {
 
 Get the Validation specified by uuid or name.
 
-Response uses the Validation json schema.
+Response uses the LegacyValidation json schema.
 
 =cut
 

--- a/lib/Conch/Controller/ValidationPlan.pm
+++ b/lib/Conch/Controller/ValidationPlan.pm
@@ -8,7 +8,7 @@ use Conch::UUID 'is_uuid';
 
 =head1 NAME
 
-Conch::Controller::Validation
+Conch::Controller::ValidationPlan
 
 Controller for managing Validation Plans
 

--- a/lib/Conch/Controller/ValidationPlan.pm
+++ b/lib/Conch/Controller/ValidationPlan.pm
@@ -18,7 +18,7 @@ Controller for managing Validation Plans
 
 List all available Validation Plans.
 
-Response uses the ValidationPlans json schema.
+Response uses the LegacyValidationPlans json schema.
 
 =cut
 
@@ -30,14 +30,14 @@ sub get_all ($c) {
 
 =head2 find_validation_plan
 
-Chainable action that uses the C<validation_plan_id_or_name> provided in the stash
+Chainable action that uses the C<legacy_validation_plan_id_or_name> provided in the stash
 (usually via the request URL) to look up a validation_plan, and stashes the result in
-C<validation_plan>.
+C<legacy_validation_plan>.
 
 =cut
 
 sub find_validation_plan($c) {
-    my $identifier = $c->stash('validation_plan_id_or_name');
+    my $identifier = $c->stash('legacy_validation_plan_id_or_name');
 
     my $validation_plan = $c->db_validation_plans->active->search({
         (is_uuid($identifier) ? 'id' : 'name') => $identifier,
@@ -49,7 +49,7 @@ sub find_validation_plan($c) {
     }
 
     $c->log->debug('Found validation plan '.$validation_plan->id);
-    $c->stash('validation_plan', $validation_plan);
+    $c->stash('legacy_validation_plan', $validation_plan);
     return 1;
 }
 
@@ -57,12 +57,12 @@ sub find_validation_plan($c) {
 
 Get the (active) Validation Plan specified by uuid or name.
 
-Response uses the ValidationPlan json schema.
+Response uses the LegacyValidationPlan json schema.
 
 =cut
 
 sub get ($c) {
-    return $c->status(200, $c->stash('validation_plan'));
+    return $c->status(200, $c->stash('legacy_validation_plan'));
 }
 
 =head2 get_validations
@@ -74,13 +74,13 @@ Response uses the LegacyValidations json schema.
 =cut
 
 sub get_validations ($c) {
-    my @validations = $c->stash('validation_plan')
+    my @validations = $c->stash('legacy_validation_plan')
         ->related_resultset('validation_plan_members')
         ->related_resultset('validation')
         ->order_by([ 'validation.name', 'validation.version' ])
         ->all;
 
-    $c->log->debug('Found '.scalar(@validations).' validations for validation plan '.$c->stash('validation_plan')->id);
+    $c->log->debug('Found '.scalar(@validations).' validations for validation plan '.$c->stash('legacy_validation_plan')->id);
 
     $c->status(200, \@validations);
 }

--- a/lib/Conch/Controller/ValidationPlan.pm
+++ b/lib/Conch/Controller/ValidationPlan.pm
@@ -69,7 +69,7 @@ sub get ($c) {
 
 List all Validations associated with the Validation Plan, both active and deactivated.
 
-Response uses the Validations json schema.
+Response uses the LegacyValidations json schema.
 
 =cut
 

--- a/lib/Conch/Route.pm
+++ b/lib/Conch/Route.pm
@@ -22,6 +22,8 @@ use Conch::Route::RackLayout;
 use Conch::Route::HardwareVendor;
 use Conch::Route::Organization;
 use Conch::Route::Build;
+use Conch::Route::ValidationPlan;
+use Conch::Route::ValidationState;
 
 =pod
 
@@ -148,7 +150,7 @@ Returns the root node.
     Conch::Route::Relay->routes($secured->any('/relay'));
     Conch::Route::User->routes($secured->any('/user'));
     Conch::Route::HardwareProduct->routes($secured->any('/hardware_product'));
-    Conch::Route::Validation->routes($secured);
+    Conch::Route::Validation->routes($secured->any('/validation'));
     Conch::Route::Datacenter->routes($secured->any('/dc'));
     Conch::Route::DatacenterRoom->routes($secured->any('/room'));
     Conch::Route::RackRole->routes($secured->any('/rack_role'));
@@ -157,6 +159,8 @@ Returns the root node.
     Conch::Route::HardwareVendor->routes($secured->any('/hardware_vendor'));
     Conch::Route::Organization->routes($secured->any('/organization'));
     Conch::Route::Build->routes($secured->any('/build'));
+    Conch::Route::ValidationPlan->routes($secured->any('/validation_plan'));
+    Conch::Route::ValidationState->routes($secured->any('/validation_state'));
 
     # find all the top level path components: these are the only paths that we will send rollbar alerts for
     state sub find_paths ($route) {
@@ -326,9 +330,17 @@ See L<Conch::Route::JSONSchema/unsecured_routes>
 
 See L<Conch::Route::User/routes>
 
-=head2 C<* /validation>, C<* /validation_plan>, C<* /validation_state>
+=head2 C<* /validation>
 
 See L<Conch::Route::Validation/routes>
+
+=head2 C<* /validation_plan>
+
+See L<Conch::Route::ValidationPlan/routes>
+
+=head2 C<* /validation_state>
+
+See L<Conch::Route::ValidationState/routes>
 
 =head2 C<* /workspace>
 

--- a/lib/Conch/Route/Device.pm
+++ b/lib/Conch/Route/Device.pm
@@ -94,9 +94,11 @@ sub routes {
         }
 
         # POST /device/:device_id_or_serial_number/validation/:validation_id
-        $with_device_ro->post('/validation/<validation_id:uuid>')->to('device_validation#validate');
+        $with_device_ro->post('/validation/<validation_id:uuid>')
+            ->to('device_validation#validate', deprecated => 'v4.0');
         # POST /device/:device_id_or_serial_number/validation_plan/:validation_plan_id
-        $with_device_ro->post('/validation_plan/<validation_plan_id:uuid>')->to('device_validation#run_validation_plan');
+        $with_device_ro->post('/validation_plan/<validation_plan_id:uuid>')
+            ->to('device_validation#run_validation_plan', deprecated => 'v4.0');
         # GET /device/:device_id_or_serial_number/validation_state?status=<pass|fail|error>&status=...
         $with_device->get('/validation_state')->to('device_validation#get_validation_state');
 
@@ -423,6 +425,8 @@ otherwise.
 
 Does not store validation results.
 
+This endpoint is B<deprecated> and will be removed in Conch API v4.0.
+
 =over 4
 
 =item * User requires the read-only role
@@ -438,6 +442,8 @@ Does not store validation results.
 =head2 C<POST /device/:device_id_or_serial_number/validation_plan/:validation_plan_id>
 
 Does not store validation results.
+
+This endpoint is B<deprecated> and will be removed in Conch API v4.0.
 
 =over 4
 

--- a/lib/Conch/Route/Device.pm
+++ b/lib/Conch/Route/Device.pm
@@ -435,7 +435,7 @@ This endpoint is B<deprecated> and will be removed in Conch API v4.0.
 
 =item * Request: F<request.yaml#/definitions/DeviceReport>
 
-=item * Response: F<response.yaml#/definitions/ValidationResults>
+=item * Response: F<response.yaml#/definitions/LegacyValidationResults>
 
 =back
 
@@ -453,7 +453,7 @@ This endpoint is B<deprecated> and will be removed in Conch API v4.0.
 
 =item * Request: F<request.yaml#/definitions/DeviceReport>
 
-=item * Response: F<response.yaml#/definitions/ValidationResults>
+=item * Response: F<response.yaml#/definitions/LegacyValidationResults>
 
 =back
 

--- a/lib/Conch/Route/Validation.pm
+++ b/lib/Conch/Route/Validation.pm
@@ -14,21 +14,23 @@ Conch::Route::Validation
 
 Sets up the routes for /validation.
 
+All routes are B<deprecated> and will be removed in Conch API v3.1.
+
 =cut
 
 sub routes {
     my $class = shift;
     my $v = shift;  # secured, under /validation
 
-    $v->to({ controller => 'validation' });
+    $v->to(controller => 'validation', deprecated => 'v3.1');
 
     # GET /validation
     $v->get('/')->to('#get_all');
 
     {
-        my $with_validation = $v->under('/:validation_id_or_name')->to('#find_validation');
+        my $with_validation = $v->under('/:legacy_validation_id_or_name')->to('#find_validation');
 
-        # GET /validation/:validation_id_or_name
+        # GET /validation/:legacy_validation_id_or_name
         $with_validation->get('/')->to('#get');
     }
 }
@@ -48,17 +50,17 @@ All routes require authentication.
 
 =item * Controller/Action: L<Conch::Controller::Validation/get_all>
 
-=item * Response: F<response.yaml#/definitions/Validations>
+=item * Response: F<response.yaml#/definitions/LegacyValidations>
 
 =back
 
-=head2 C<GET /validation/:validation_id_or_name>
+=head2 C<GET /validation/:legacy_validation_id_or_name>
 
 =over 4
 
 =item * Controller/Action: L<Conch::Controller::Validation/get>
 
-=item * Response: F<response.yaml#/definitions/Validation>
+=item * Response: F<response.yaml#/definitions/LegacyValidation>
 
 =back
 

--- a/lib/Conch/Route/Validation.pm
+++ b/lib/Conch/Route/Validation.pm
@@ -12,16 +12,14 @@ Conch::Route::Validation
 
 =head2 routes
 
-Sets up the routes for /validation, /validation_plan and /validation_state.
+Sets up the routes for /validation.
 
 =cut
 
 sub routes {
     my $class = shift;
-    my $r = shift;  # secured, under /
+    my $v = shift;  # secured, under /validation
 
-    # all these /validation routes go to the Validation controller
-    my $v = $r->any('/validation');
     $v->to({ controller => 'validation' });
 
     # GET /validation
@@ -32,32 +30,6 @@ sub routes {
 
         # GET /validation/:validation_id_or_name
         $with_validation->get('/')->to('#get');
-    }
-
-
-    # all these /validation_plan routes go to the ValidationPlan controller
-    my $vp = $r->any('/validation_plan');
-    $vp->to({ controller => 'validation_plan' });
-
-    # GET /validation_plan
-    $vp->get('/')->to('#get_all');
-
-    {
-        my $with_plan = $vp->under('/:validation_plan_id_or_name')->to('#find_validation_plan');
-
-        # GET /validation_plan/:validation_plan_id_or_name
-        $with_plan->get('/')->to('#get');
-
-        # GET /validation_plan/:validation_plan_id_or_name/validation
-        $with_plan->get('/validation')->to('#get_validations');
-    }
-
-    {
-        my $vs = $r->any('/validation_state');
-        $vs->to({ controller => 'validation_state' });
-
-        # GET /validation_state/:validation_state_id
-        $vs->get('/<validation_state_id:uuid>')->to('#get');
     }
 }
 
@@ -87,46 +59,6 @@ All routes require authentication.
 =item * Controller/Action: L<Conch::Controller::Validation/get>
 
 =item * Response: F<response.yaml#/definitions/Validation>
-
-=back
-
-=head2 C<GET /validation_plan>
-
-=over 4
-
-=item * Controller/Action: L<Conch::Controller::ValidationPlan/get_all>
-
-=item * Response: F<response.yaml#/definitions/ValidationPlans>
-
-=back
-
-=head2 C<GET /validation_plan/:validation_plan_id_or_name>
-
-=over 4
-
-=item * Controller/Action: L<Conch::Controller::ValidationPlan/get>
-
-=item * Response: F<response.yaml#/definitions/ValidationPlan>
-
-=back
-
-=head2 C<GET /validation_plan/:validation_plan_id_or_name/validation>
-
-=over 4
-
-=item * Controller/Action: L<Conch::Controller::ValidationPlan/validations>
-
-=item * Response: F<response.yaml#/definitions/Validations>
-
-=back
-
-=head2 C<GET /validation_state/:validation_state_id>
-
-=over 4
-
-=item * Controller/Action: L<Conch::Controller::ValidationState/get>
-
-=item * Response: F<response.yaml#/definitions/ValidationStateWithResults>
 
 =back
 

--- a/lib/Conch/Route/ValidationPlan.pm
+++ b/lib/Conch/Route/ValidationPlan.pm
@@ -14,24 +14,26 @@ Conch::Route::ValidationPlan
 
 Sets up the routes for /validation_plan.
 
+All routes are B<deprecated> and will be removed in Conch API v4.0.
+
 =cut
 
 sub routes {
     my $class = shift;
     my $vp = shift; # secured, under /validation_plan
 
-    $vp->to({ controller => 'validation_plan' });
+    $vp->to(controller => 'validation_plan', deprecated => 'v4.0');
 
     # GET /validation_plan
     $vp->get('/')->to('#get_all');
 
     {
-        my $with_plan = $vp->under('/:validation_plan_id_or_name')->to('#find_validation_plan');
+        my $with_plan = $vp->under('/:legacy_validation_plan_id_or_name')->to('#find_validation_plan');
 
-        # GET /validation_plan/:validation_plan_id_or_name
+        # GET /validation_plan/:legacy_validation_plan_id_or_name
         $with_plan->get('/')->to('#get');
 
-        # GET /validation_plan/:validation_plan_id_or_name/validation
+        # GET /validation_plan/:legacy_validation_plan_id_or_name/validation
         $with_plan->get('/validation')->to('#get_validations');
     }
 }
@@ -51,21 +53,21 @@ All routes require authentication.
 
 =item * Controller/Action: L<Conch::Controller::ValidationPlan/get_all>
 
-=item * Response: F<response.yaml#/definitions/ValidationPlans>
+=item * Response: F<response.yaml#/definitions/LegacyValidationPlans>
 
 =back
 
-=head2 C<GET /validation_plan/:validation_plan_id_or_name>
+=head2 C<GET /validation_plan/:legacy_validation_plan_id_or_name>
 
 =over 4
 
 =item * Controller/Action: L<Conch::Controller::ValidationPlan/get>
 
-=item * Response: F<response.yaml#/definitions/ValidationPlan>
+=item * Response: F<response.yaml#/definitions/LegacyValidationPlan>
 
 =back
 
-=head2 C<GET /validation_plan/:validation_plan_id_or_name/validation>
+=head2 C<GET /validation_plan/:legacy_validation_plan_id_or_name/validation>
 
 =over 4
 

--- a/lib/Conch/Route/ValidationPlan.pm
+++ b/lib/Conch/Route/ValidationPlan.pm
@@ -71,7 +71,7 @@ All routes require authentication.
 
 =item * Controller/Action: L<Conch::Controller::ValidationPlan/validations>
 
-=item * Response: F<response.yaml#/definitions/Validations>
+=item * Response: F<response.yaml#/definitions/LegacyValidations>
 
 =back
 

--- a/lib/Conch/Route/ValidationPlan.pm
+++ b/lib/Conch/Route/ValidationPlan.pm
@@ -1,0 +1,87 @@
+package Conch::Route::ValidationPlan;
+
+use Mojo::Base -strict;
+
+=pod
+
+=head1 NAME
+
+Conch::Route::ValidationPlan
+
+=head1 METHODS
+
+=head2 routes
+
+Sets up the routes for /validation_plan.
+
+=cut
+
+sub routes {
+    my $class = shift;
+    my $vp = shift; # secured, under /validation_plan
+
+    $vp->to({ controller => 'validation_plan' });
+
+    # GET /validation_plan
+    $vp->get('/')->to('#get_all');
+
+    {
+        my $with_plan = $vp->under('/:validation_plan_id_or_name')->to('#find_validation_plan');
+
+        # GET /validation_plan/:validation_plan_id_or_name
+        $with_plan->get('/')->to('#get');
+
+        # GET /validation_plan/:validation_plan_id_or_name/validation
+        $with_plan->get('/validation')->to('#get_validations');
+    }
+}
+
+1;
+__END__
+
+=pod
+
+=head1 ROUTE ENDPOINTS
+
+All routes require authentication.
+
+=head2 C<GET /validation_plan>
+
+=over 4
+
+=item * Controller/Action: L<Conch::Controller::ValidationPlan/get_all>
+
+=item * Response: F<response.yaml#/definitions/ValidationPlans>
+
+=back
+
+=head2 C<GET /validation_plan/:validation_plan_id_or_name>
+
+=over 4
+
+=item * Controller/Action: L<Conch::Controller::ValidationPlan/get>
+
+=item * Response: F<response.yaml#/definitions/ValidationPlan>
+
+=back
+
+=head2 C<GET /validation_plan/:validation_plan_id_or_name/validation>
+
+=over 4
+
+=item * Controller/Action: L<Conch::Controller::ValidationPlan/validations>
+
+=item * Response: F<response.yaml#/definitions/Validations>
+
+=back
+
+=head1 LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at L<https://www.mozilla.org/en-US/MPL/2.0/>.
+
+=cut
+# vim: set ts=4 sts=4 sw=4 et :

--- a/lib/Conch/Route/ValidationState.pm
+++ b/lib/Conch/Route/ValidationState.pm
@@ -1,0 +1,57 @@
+package Conch::Route::ValidationState;
+
+use Mojo::Base -strict;
+
+=pod
+
+=head1 NAME
+
+Conch::Route::ValidationState
+
+=head1 METHODS
+
+=head2 routes
+
+Sets up the routes for /validation_state.
+
+=cut
+
+sub routes {
+    my $class = shift;
+    my $vs = shift; # secured, under /validation_state
+
+    $vs->to({ controller => 'validation_state' });
+
+    # GET /validation_state/:validation_state_id
+    $vs->get('/<validation_state_id:uuid>')->to('#get');
+}
+
+1;
+__END__
+
+=pod
+
+=head1 ROUTE ENDPOINTS
+
+All routes require authentication.
+
+=head2 C<GET /validation_state/:validation_state_id>
+
+=over 4
+
+=item * Controller/Action: L<Conch::Controller::ValidationState/get>
+
+=item * Response: F<response.yaml#/definitions/ValidationStateWithResults>
+
+=back
+
+=head1 LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at L<https://www.mozilla.org/en-US/MPL/2.0/>.
+
+=cut
+# vim: set ts=4 sts=4 sw=4 et :

--- a/t/integration/crud/validations.t
+++ b/t/integration/crud/validations.t
@@ -26,7 +26,7 @@ my @validations = $t->tx->res->json->@*;
 
 $t->get_ok('/validation_plan')
     ->status_is(200)
-    ->json_schema_is('ValidationPlans')
+    ->json_schema_is('LegacyValidationPlans')
     ->json_cmp_deeply([
         {
             id => re(Conch::UUID::UUID_FORMAT),
@@ -41,12 +41,12 @@ my @validation_plans = $t->tx->res->json->@*;
 
 $t->get_ok('/validation_plan/'.$validation_plans[0]->{id})
     ->status_is(200)
-    ->json_schema_is('ValidationPlan')
+    ->json_schema_is('LegacyValidationPlan')
     ->json_is($validation_plans[0]);
 
 $t->get_ok('/validation_plan/Conch v1 Legacy Plan: Server')
     ->status_is(200)
-    ->json_schema_is('ValidationPlan')
+    ->json_schema_is('LegacyValidationPlan')
     ->json_is($validation_plans[0]);
 
 $t->get_ok('/validation_plan/'.$validation_plans[0]->{id}.'/validation')

--- a/t/integration/crud/validations.t
+++ b/t/integration/crud/validations.t
@@ -19,7 +19,7 @@ $t->authenticate;
 
 $t->get_ok('/validation')
     ->status_is(200)
-    ->json_schema_is('Validations');
+    ->json_schema_is('LegacyValidations');
 
 my $validation_id = $t->tx->res->json->[0]->{id};
 my @validations = $t->tx->res->json->@*;
@@ -51,22 +51,22 @@ $t->get_ok('/validation_plan/Conch v1 Legacy Plan: Server')
 
 $t->get_ok('/validation_plan/'.$validation_plans[0]->{id}.'/validation')
     ->status_is(200)
-    ->json_schema_is('Validations')
+    ->json_schema_is('LegacyValidations')
     ->json_is([ $validations[0] ]);
 
 $t->get_ok('/validation_plan/Conch v1 Legacy Plan: Server/validation')
     ->status_is(200)
-    ->json_schema_is('Validations')
+    ->json_schema_is('LegacyValidations')
     ->json_is([ $validations[0] ]);
 
 $t->get_ok('/validation/'.$validation_id)
     ->status_is(200)
-    ->json_schema_is('Validation')
+    ->json_schema_is('LegacyValidation')
     ->json_is($validations[0]);
 
 $t->get_ok('/validation/'.$validations[0]->{name})
     ->status_is(200)
-    ->json_schema_is('Validation')
+    ->json_schema_is('LegacyValidation')
     ->json_is($validations[0]);
 
 done_testing;

--- a/t/integration/device-validations.t
+++ b/t/integration/device-validations.t
@@ -71,7 +71,7 @@ subtest 'test validating a device' => sub {
     $t->post_ok("/device/TEST/validation/$validation_id",
             { 'Content-Type' => 'application/json' }, $good_report)
         ->status_is(200)
-        ->json_schema_is('ValidationResults')
+        ->json_schema_is('LegacyValidationResults')
         ->json_cmp_deeply(array_each(superhashof({
             id => undef,
         })));
@@ -86,7 +86,7 @@ subtest 'test validating a device' => sub {
     $t->post_ok('/device/TEST/validation_plan/'.$test_validation_plan->id,
             { 'Content-Type' => 'application/json' }, $good_report)
         ->status_is(200)
-        ->json_schema_is('ValidationResults')
+        ->json_schema_is('LegacyValidationResults')
         ->json_is($validation_results);
 };
 


### PR DESCRIPTION
Nothing is removed yet, but clients should be getting off these endpoints/relying on these properties ASAP.

- deprecate GET /validation and GET /validation/:id, to be removed by v3.1
- deprecate old "test validation" endpoints, to be removed by v3.3
- hardware_product.validation_plan_id is deprecated and will be removed soon
- validation_plan_id will be removed from validation results by v3.1
- deprecate all /validation_plan routes, to be removed in v4.0