### PR TITLE
endpoint improvements

### DIFF
--- a/docs/json-schema/query_params.json
+++ b/docs/json-schema/query_params.json
@@ -85,6 +85,30 @@
       },
       "type" : "object"
     },
+    "BuildRacks" : {
+      "additionalProperties" : false,
+      "properties" : {
+        "ids_only" : {
+          "$ref" : "#/definitions/boolean_integer_default_false"
+        },
+        "phase" : {
+          "oneOf" : [
+            {
+              "$ref" : "common.json#/definitions/device_phase"
+            },
+            {
+              "items" : {
+                "$ref" : "common.json#/definitions/device_phase"
+              },
+              "minItems" : 2,
+              "type" : "array",
+              "uniqueItems" : true
+            }
+          ]
+        }
+      },
+      "type" : "object"
+    },
     "ChangePassword" : {
       "additionalProperties" : false,
       "properties" : {

--- a/docs/json-schema/query_params.json
+++ b/docs/json-schema/query_params.json
@@ -5,6 +5,14 @@
     "BuildDevices" : {
       "additionalProperties" : false,
       "not" : {
+        "properties" : {
+          "ids_only" : {
+            "const" : 1
+          },
+          "serials_only" : {
+            "const" : 1
+          }
+        },
         "required" : [
           "ids_only",
           "serials_only"

--- a/docs/json-schema/query_params.json
+++ b/docs/json-schema/query_params.json
@@ -4,21 +4,34 @@
   "definitions" : {
     "BuildDevices" : {
       "additionalProperties" : false,
-      "not" : {
-        "properties" : {
-          "ids_only" : {
-            "const" : 1
-          },
-          "serials_only" : {
-            "const" : 1
+      "allOf" : [
+        {
+          "not" : {
+            "properties" : {
+              "ids_only" : {
+                "const" : 1
+              },
+              "serials_only" : {
+                "const" : 1
+              }
+            },
+            "required" : [
+              "ids_only",
+              "serials_only"
+            ],
+            "type" : "object"
           }
         },
-        "required" : [
-          "ids_only",
-          "serials_only"
-        ],
-        "type" : "object"
-      },
+        {
+          "not" : {
+            "required" : [
+              "phase_earlier_than",
+              "phase"
+            ],
+            "type" : "object"
+          }
+        }
+      ],
       "properties" : {
         "active_minutes" : {
           "$ref" : "common.json#/definitions/non_negative_integer"
@@ -40,6 +53,21 @@
         },
         "ids_only" : {
           "$ref" : "#/definitions/boolean_integer_default_false"
+        },
+        "phase" : {
+          "oneOf" : [
+            {
+              "$ref" : "common.json#/definitions/device_phase"
+            },
+            {
+              "items" : {
+                "$ref" : "common.json#/definitions/device_phase"
+              },
+              "minItems" : 2,
+              "type" : "array",
+              "uniqueItems" : true
+            }
+          ]
         },
         "phase_earlier_than" : {
           "oneOf" : [

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -3018,9 +3018,59 @@
       "type" : "array",
       "uniqueItems" : true
     },
-    "UsersDetailed" : {
+    "Users" : {
       "items" : {
-        "$ref" : "#/definitions/UserDetailed"
+        "additionalProperties" : false,
+        "properties" : {
+          "created" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "email" : {
+            "$ref" : "common.json#/definitions/email_address"
+          },
+          "force_password_change" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "$ref" : "common.json#/definitions/uuid"
+          },
+          "is_admin" : {
+            "type" : "boolean"
+          },
+          "last_login" : {
+            "format" : "date-time",
+            "type" : [
+              "null",
+              "string"
+            ]
+          },
+          "last_seen" : {
+            "format" : "date-time",
+            "type" : [
+              "null",
+              "string"
+            ]
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "refuse_session_auth" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [
+          "id",
+          "name",
+          "email",
+          "created",
+          "last_login",
+          "last_seen",
+          "refuse_session_auth",
+          "force_password_change",
+          "is_admin"
+        ],
+        "type" : "object"
       },
       "type" : "array",
       "uniqueItems" : true

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -2486,6 +2486,13 @@
       "type" : "array",
       "uniqueItems" : true
     },
+    "RackIds" : {
+      "items" : {
+        "$ref" : "common.json#/definitions/uuid"
+      },
+      "type" : "array",
+      "uniqueItems" : true
+    },
     "RackLayout" : {
       "additionalProperties" : false,
       "properties" : {

--- a/docs/modules/Conch::Controller::Build.md
+++ b/docs/modules/Conch::Controller::Build.md
@@ -165,7 +165,16 @@ Requires the 'read/write' role on the build.
 Get the racks in this build.
 Requires the 'read-only' role on the build.
 
-Response uses the Racks json schema.
+Supports these query parameters to constrain results (which are ANDed together for the search,
+not ORed):
+
+```
+phase=<value>       only racks with phase matching the provided value
+    (can be used more than once to search for ANY of the specified phase values)
+ids_only=1          only return rack ids, not full data
+```
+
+Response uses the Racks json schema, or RackIds iff `ids_only=1`.
 
 ### add\_rack
 

--- a/docs/modules/Conch::Controller::Build.md
+++ b/docs/modules/Conch::Controller::Build.md
@@ -126,6 +126,8 @@ not ORed):
 ```
 health=<value>      only devices with health matching the provided value
     (can be used more than once to search for ANY of the specified health values)
+phase=<value>       only devices with phase matching the provided value
+    (can be used more than once to search for ANY of the specified phase values)
 active_minutes=X    only devices last seen (via a report relay) within X minutes
 ids_only=1          only return device ids, not full data
 serials_only=1      only return device serial numbers, not full data

--- a/docs/modules/Conch::Controller::User.md
+++ b/docs/modules/Conch::Controller::User.md
@@ -106,8 +106,8 @@ The response uses the UserError json schema for some error conditions; on succes
 
 ### get\_all
 
-List all active users and their workspaces, builds and organizations. System admin only.
-Response uses the UsersDetailed json schema.
+List all active users. System admin only.
+Response uses the Users json schema.
 
 ### create
 

--- a/docs/modules/Conch::Route::Build.md
+++ b/docs/modules/Conch::Route::Build.md
@@ -158,9 +158,15 @@ read-write role on the device (via a workspace or build; see ["routes" in Conch:
 
 ### `GET /build/:build_id_or_name/rack`
 
+Accepts the following optional query parameters:
+
+- `phase=:value` show only racks with the phase matching the provided value
+(can be used more than once)
+- `ids_only=1` only return rack IDs, not full rack details
+
 - Requires system admin authorization or the read-only role on the build
 - Controller/Action: ["get\_racks" in Conch::Controller::Build](../modules/Conch%3A%3AController%3A%3ABuild#get_racks)
-- Response: [response.json#/definitions/Racks](../json-schema/response.json#/definitions/Racks)
+- Response: one of [response.json#/definitions/Racks](../json-schema/response.json#/definitions/Racks) or [response.json#/definitions/RackIds](../json-schema/response.json#/definitions/RackIds)
 
 ### `POST /build/:build_id_or_name/rack/:rack_id_or_name`
 

--- a/docs/modules/Conch::Route::Build.md
+++ b/docs/modules/Conch::Route::Build.md
@@ -119,6 +119,8 @@ Accepts the following optional query parameters:
 
 - `health=:value` show only devices with the health matching the provided value
 (can be used more than once)
+- `phase=:value` show only devices with the phase matching the provided value
+(can be used more than once)
 - `active_minutes=:X` show only devices which have reported within the last X minutes
 - `ids_only=1` only return device IDs, not full device details
 

--- a/docs/modules/Conch::Route::User.md
+++ b/docs/modules/Conch::Route::User.md
@@ -171,7 +171,7 @@ Optionally accepts the following query parameters:
 
 - Requires system admin authorization
 - Controller/Action: ["get\_all" in Conch::Controller::User](../modules/Conch%3A%3AController%3A%3AUser#get_all)
-- Response: [response.json#/definitions/UsersDetailed](../json-schema/response.json#/definitions/UsersDetailed)
+- Response: [response.json#/definitions/Users](../json-schema/response.json#/definitions/Users)
 
 ### `POST /user?send_mail=<1|0>`
 

--- a/json-schema/query_params.yaml
+++ b/json-schema/query_params.yaml
@@ -215,6 +215,20 @@ definitions:
       - not:
           type: object
           required: [ phase_earlier_than, phase ]
+  BuildRacks:
+    type: object
+    additionalProperties: false
+    properties:
+      phase:
+        oneOf:
+          - $ref: common.yaml#/definitions/device_phase
+          - type: array
+            uniqueItems: true
+            minItems: 2
+            items:
+              $ref: common.yaml#/definitions/device_phase
+      ids_only:
+        $ref: '#/definitions/boolean_integer_default_false'
   ProcessDeviceReport:
     type: object
     additionalProperties: false

--- a/json-schema/query_params.yaml
+++ b/json-schema/query_params.yaml
@@ -200,6 +200,11 @@ definitions:
       required:
         - ids_only
         - serials_only
+      properties:
+        ids_only:
+          const: 1
+        serials_only:
+          const: 1
   ProcessDeviceReport:
     type: object
     additionalProperties: false

--- a/json-schema/query_params.yaml
+++ b/json-schema/query_params.yaml
@@ -189,22 +189,32 @@ definitions:
             minItems: 2
             items:
               $ref: common.yaml#/definitions/device_health
+      phase:
+        oneOf:
+          - $ref: common.yaml#/definitions/device_phase
+          - type: array
+            uniqueItems: true
+            minItems: 2
+            items:
+              $ref: common.yaml#/definitions/device_phase
       active_minutes:
         $ref: common.yaml#/definitions/non_negative_integer
       ids_only:
         $ref: '#/definitions/boolean_integer_default_false'
       serials_only:
         $ref: '#/definitions/boolean_integer_default_false'
-    not:
-      type: object
-      required:
-        - ids_only
-        - serials_only
-      properties:
-        ids_only:
-          const: 1
-        serials_only:
-          const: 1
+    allOf:
+      - not:
+          type: object
+          required: [ ids_only, serials_only ]
+          properties:
+            ids_only:
+              const: 1
+            serials_only:
+              const: 1
+      - not:
+          type: object
+          required: [ phase_earlier_than, phase ]
   ProcessDeviceReport:
     type: object
     additionalProperties: false

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -1431,6 +1431,11 @@ definitions:
           - $ref: common.yaml#/definitions/mojo_standard_placeholder
       links:
         $ref: common.yaml#/definitions/links
+  RackIds:
+    type: array
+    uniqueItems: true
+    items:
+      $ref: common.yaml#/definitions/uuid
   RackRole:
     type: object
     additionalProperties: false

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -1674,11 +1674,44 @@ definitions:
               $ref: common.yaml#/definitions/role
             role_via_organization_id:
               $ref: common.yaml#/definitions/uuid
-  UsersDetailed:
+  Users:
     type: array
     uniqueItems: true
     items:
-       $ref: '#/definitions/UserDetailed'
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - email
+        - created
+        - last_login
+        - last_seen
+        - refuse_session_auth
+        - force_password_change
+        - is_admin
+      properties:
+        id:
+          $ref: common.yaml#/definitions/uuid
+        name:
+          type: string
+        email:
+          $ref: common.yaml#/definitions/email_address
+        created:
+          type: string
+          format: date-time
+        last_login:
+          type: [ 'null', string ]
+          format: date-time
+        last_seen:
+          type: [ 'null', string ]
+          format: date-time
+        refuse_session_auth:
+          type: boolean
+        force_password_change:
+          type: boolean
+        is_admin:
+          type: boolean
   UserSettings:
     type: object
     propertyNames:

--- a/lib/Conch/Controller/Build.pm
+++ b/lib/Conch/Controller/Build.pm
@@ -677,7 +677,8 @@ sub find_devices ($c) {
     return if not $params;
 
     # production devices do not consider location, interface data to be canonical
-    my $bad_phase = $params->{phase_earlier_than} // 'production';
+    my $bad_phase = exists $params->{phase} ? undef
+        : $params->{phase_earlier_than} // 'production';
 
     my $build_id = $c->stash('build_id') // { '=' => $c->stash('build_rs')->get_column('id')->as_query };
 
@@ -712,6 +713,8 @@ not ORed):
 
     health=<value>      only devices with health matching the provided value
         (can be used more than once to search for ANY of the specified health values)
+    phase=<value>       only devices with phase matching the provided value
+        (can be used more than once to search for ANY of the specified phase values)
     active_minutes=X    only devices last seen (via a report relay) within X minutes
     ids_only=1          only return device ids, not full data
     serials_only=1      only return device serial numbers, not full data
@@ -728,6 +731,7 @@ sub get_devices ($c) {
     my $rs = $c->stash('build_devices_rs');
 
     $rs = $rs->search({ health => $params->{health} }) if $params->{health};
+    $rs = $rs->search({ 'device.phase' => $params->{phase} }) if $params->{phase};
 
     $rs = $rs->search({ last_seen => { '>' => \[ 'now() - ?::interval', $params->{active_minutes}.' minutes' ] } })
         if $params->{active_minutes};

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -435,22 +435,15 @@ sub update ($c) {
 
 =head2 get_all
 
-List all active users and their workspaces, builds and organizations. System admin only.
-Response uses the UsersDetailed json schema.
+List all active users. System admin only.
+Response uses the Users json schema.
 
 =cut
 
 sub get_all ($c) {
     my $user_rs = $c->db_user_accounts
         ->active
-        ->prefetch({
-                user_workspace_roles => 'workspace',
-                user_organization_roles => { organization => {
-                        organization_build_roles => 'build',
-                    } },
-                user_build_roles => 'build',
-            })
-        ->order_by([ map $_.'.name', qw(user_account workspace organization build) ]);
+        ->order_by('name');
 
     return $c->status(200, [ $user_rs->all ]);
 }

--- a/lib/Conch/Route/Build.pm
+++ b/lib/Conch/Route/Build.pm
@@ -313,6 +313,9 @@ Accepts the following optional query parameters:
 =item * C<health=:value> show only devices with the health matching the provided value
 (can be used more than once)
 
+=item * C<phase=:value> show only devices with the phase matching the provided value
+(can be used more than once)
+
 =item * C<active_minutes=:X> show only devices which have reported within the last X minutes
 
 =item * C<ids_only=1> only return device IDs, not full device details

--- a/lib/Conch/Route/Build.pm
+++ b/lib/Conch/Route/Build.pm
@@ -387,13 +387,24 @@ read-write role on the device (via a workspace or build; see L<Conch::Route::Dev
 
 =head2 C<GET /build/:build_id_or_name/rack>
 
+Accepts the following optional query parameters:
+
+=over 4
+
+=item * C<phase=:value> show only racks with the phase matching the provided value
+(can be used more than once)
+
+=item * C<ids_only=1> only return rack IDs, not full rack details
+
+=back
+
 =over 4
 
 =item * Requires system admin authorization or the read-only role on the build
 
 =item * Controller/Action: L<Conch::Controller::Build/get_racks>
 
-=item * Response: F<response.yaml#/definitions/Racks>
+=item * Response: one of F<response.yaml#/definitions/Racks> or F<response.yaml#/definitions/RackIds>
 
 =back
 

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -427,7 +427,7 @@ Optionally accepts the following query parameters:
 
 =item * Controller/Action: L<Conch::Controller::User/get_all>
 
-=item * Response: F<response.yaml#/definitions/UsersDetailed>
+=item * Response: F<response.yaml#/definitions/Users>
 
 =back
 

--- a/t/integration/crud/build.t
+++ b/t/integration/crud/build.t
@@ -806,10 +806,11 @@ $t->get_ok('/build/our second build/device?health=fail')
     ->json_schema_is('Devices')
     ->json_is([]);
 
-$t->get_ok('/build/our second build/device?health=unknown')
+$t->get_ok('/build/our second build/device?health=unknown'.$_)
     ->status_is(200)
     ->json_schema_is('Devices')
-    ->json_is($devices);
+    ->json_is($devices)
+        foreach ('', '&ids_only=0&serials_only=0');
 
 $t->get_ok('/build/our second build/device?ids_only=1&serials_only=1')
     ->status_is(400)

--- a/t/integration/crud/build.t
+++ b/t/integration/crud/build.t
@@ -812,6 +812,16 @@ $t->get_ok('/build/our second build/device?health=unknown'.$_)
     ->json_is($devices)
         foreach ('', '&ids_only=0&serials_only=0');
 
+$t->get_ok('/build/our second build/device?phase=integration')
+    ->status_is(200)
+    ->json_schema_is('Devices')
+    ->json_is($devices);
+
+$t->get_ok('/build/our second build/device?phase=installation')
+    ->status_is(200)
+    ->json_schema_is('Devices')
+    ->json_is([]);
+
 $t->get_ok('/build/our second build/device?ids_only=1&serials_only=1')
     ->status_is(400)
     ->json_schema_is('QueryParamsValidationError')

--- a/t/integration/crud/build.t
+++ b/t/integration/crud/build.t
@@ -997,12 +997,23 @@ $t->post_ok($_)
         '/build/my first build/rack/'.$rack1->id,
         '/build/my first build/rack/'.$room1->vendor_name.':'.$rack1->name;
 
-$t->get_ok('/build/my first build/rack')
+$t->get_ok('/build/my first build/rack'.$_)
     ->status_is(200)
     ->json_schema_is('Racks')
     ->json_cmp_deeply([
         superhashof({ id => $rack1->id }),
-    ]);
+    ])
+    foreach '', '?phase=integration';
+
+$t->get_ok('/build/my first build/rack?phase=installation')
+    ->status_is(200)
+    ->json_schema_is('Racks')
+    ->json_cmp_deeply([]);
+
+$t->get_ok('/build/my first build/rack?ids_only=1')
+    ->status_is(200)
+    ->json_schema_is('RackIds')
+    ->json_cmp_deeply([ $rack1->id ]);
 
 $t->get_ok('/build/my first build/device')
     ->status_is(200)

--- a/t/integration/users.t
+++ b/t/integration/users.t
@@ -258,10 +258,10 @@ subtest 'User' => sub {
 
     $t_super->get_ok('/user')
         ->status_is(200)
-        ->json_schema_is('UsersDetailed')
+        ->json_schema_is('Users')
         ->json_cmp_deeply([
             (map +{
-                $_->%*,
+                $_->%{qw(id name email created refuse_session_auth force_password_change is_admin)},
                 last_login => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
                 last_seen => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
             }, $super_user_data, $user_detailed),
@@ -712,14 +712,14 @@ subtest 'modify another user' => sub {
 
     $t_super->get_ok('/user')
         ->status_is(200)
-        ->json_schema_is('UsersDetailed')
+        ->json_schema_is('Users')
         ->json_cmp_deeply([
-            (map +{
-                $_->%*,
-                last_login => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
-                last_seen => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
-            }, $super_user_data, $user_detailed),
-            $new_user_data,
+          (map +{
+            $_->%{qw(id name email created refuse_session_auth force_password_change is_admin)},
+            last_login => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
+            last_seen => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
+          }, $super_user_data, $user_detailed),
+          { $new_user_data->%{qw(id name email created last_login last_seen refuse_session_auth force_password_change is_admin)} },
         ]);
 
     $t_super->post_ok('/user?send_mail=0',

--- a/t/integration/users.t
+++ b/t/integration/users.t
@@ -608,6 +608,11 @@ subtest 'JWT authentication' => sub {
             },
         ]);
 
+    $t_super->post_ok('/user/'.$ro_user->email.'/revoke?login_only=0&api_only=0')
+        ->status_is(204)
+        ->log_debug_is('revoking all tokens for user rO_USer, forcing them to /login again')
+        ->email_not_sent;
+
     $t->get_ok('/me', { Authorization => "Bearer $new_jwt_token" })
         ->status_is(401, 'Cannot use token after user revocation')
         ->log_debug_is('auth failed: JWT for user_id '.$ro_user->id.' could not be found');
@@ -625,6 +630,7 @@ subtest 'JWT authentication' => sub {
         ->status_is(204)
         ->log_debug_is('revoking all tokens for user rO_USer, forcing them to /login again')
         ->email_not_sent;
+
     $t->get_ok('/me', { Authorization => "Bearer $jwt_token_2" })
         ->status_is(401, 'Cannot use after self revocation');
 


### PR DESCRIPTION
- remove organization and build data from from GET /user
- fix query parameter specification -- allow ?ids_only=0&serials_only=0
- add ?phase=value option to GET /build/:id_or_name/device
- add ?phase=value, ?ids_only options to GET /build/:id_or_name/rack