### PR TITLE
include validation name, version, description in all ValidationResults

### DIFF
--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -1918,7 +1918,10 @@
         "hint",
         "message",
         "status",
-        "validation_id"
+        "validation_id",
+        "name",
+        "version",
+        "description"
       ],
       "type" : "object"
     },

--- a/docs/modules/Conch::DB::Result::ValidationResult.md
+++ b/docs/modules/Conch::DB::Result::ValidationResult.md
@@ -124,6 +124,10 @@ Type: many\_to\_many
 
 Composing rels: ["validation\_state\_members"](#validation_state_members) -> validation\_state
 
+### TO\_JSON
+
+Include information about the validation corresponding to the result, if available.
+
 ## LICENSING
 
 Copyright Joyent, Inc.

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -910,6 +910,9 @@ definitions:
       - message
       - status
       - validation_id
+      - name
+      - version
+      - description
     properties:
       id:
         oneOf:

--- a/lib/Conch/DB/Result/ValidationResult.pm
+++ b/lib/Conch/DB/Result/ValidationResult.pm
@@ -241,6 +241,24 @@ __PACKAGE__->add_columns(
     '+device_id' => { is_serializable => 0 },
 );
 
+use experimental 'signatures';
+
+=head2 TO_JSON
+
+Include information about the validation corresponding to the result, if available.
+
+=cut
+
+sub TO_JSON ($self) {
+    my $data = $self->next::method(@_);
+
+    if (my $validation = ($self->related_resultset('validation')->get_cache // [])->[0]) {
+        $data->{$_} = $validation->$_ foreach qw(name version description);
+    }
+
+    return $data;
+}
+
 1;
 __END__
 

--- a/lib/Conch/ValidationSystem.pm
+++ b/lib/Conch/ValidationSystem.pm
@@ -326,13 +326,16 @@ sub run_validation_plan ($self, %options) {
 
         $validator->run($data);
 
-        push @validation_results, map
-            $validation_result_rs->new_result({
+        push @validation_results, map {
+            my $result = $validation_result_rs->new_result({
                 validation_id       => $validation->id,
                 device_id           => $device->id,
                 $_->%{qw(message hint status category component)},
-            }),
-            $validator->validation_results;
+            });
+            $result->related_resultset('validation')->set_cache([ $validation ]);
+            $result;
+        }
+        $validator->validation_results;
 
         $self->log->debug('validation '.$validation->name.' returned no results for device id '.$device->id)
             if not $validator->validation_results;
@@ -398,13 +401,16 @@ sub run_validation ($self, %options) {
     $validator->run($data);
 
     my $validation_result_rs = $self->schema->resultset('validation_result');
-    my @validation_results = map
-        $validation_result_rs->new_result({
+    my @validation_results = map {
+        my $result = $validation_result_rs->new_result({
             validation_id       => $validation->id,
             device_id           => $device->id,
             $_->%{qw(message hint status category component)},
-        }),
-        $validator->validation_results;
+        });
+        $result->related_resultset('validation')->set_cache([ $validation ]);
+        $result;
+    }
+    $validator->validation_results;
 
     return @validation_results;
 }

--- a/t/integration/device-reports.t
+++ b/t/integration/device-reports.t
@@ -113,6 +113,7 @@ subtest 'run report without an existing device and without making updates' => su
                 hint => ignore,
                 message => ignore,
                 status => any(qw(error fail pass)),
+                do { my $v = $_; map +($_ => $v->$_), qw(name version description) },
             }, @validations)),
         });
 


### PR DESCRIPTION
This was an oversight when the fields were added in PR #1033 (v3.0.2)

affects endpoints:
    POST /device/:device_id_or_serial_number/validation/:validation_id
    POST /device/:device_id_or_serial_number/validation_plan/:validation_plan_id
    POST /device_report?no_update_db=1