### PR TITLE
add hardware product specification annotations

### DIFF
--- a/docs/json-schema/common.json
+++ b/docs/json-schema/common.json
@@ -2,8 +2,9 @@
   "$comment" : "NOTE: This file is for human reference ONLY. For programmatic use, use the GET '/json_schema/common/$schema_name' endpoints, or within conch itself, json-schema/common.yaml.",
   "$defs" : {
     "HardwareProductSpecification" : {
-      "$comment" : "this is the structure of the hardware_product.specification database column",
+      "$comment" : "this is the structure of the hardware_product.specification database column. NOTE: by conch api v3.2 this schema will be in the json_schema table in the database (available via GET /json_schema/hardware_product/specification/latest) so it can be updated dynamically",
       "additionalProperties" : true,
+      "deprecated" : true,
       "properties" : {
         "chassis" : {
           "properties" : {
@@ -21,23 +22,28 @@
                     "type" : "object"
                   },
                   "minItems" : 1,
+                  "title" : "DIMMs",
                   "type" : "array"
                 }
               },
+              "title" : "Memory",
               "type" : "object"
             }
           },
+          "title" : "Chassis",
           "type" : "object"
         },
         "disk_size" : {
           "$comment" : "property names correspond to device report /disks/<disk serial>/model",
           "additionalProperties" : {
             "$comment" : "property values are compared to device report /disks/<disk serial>/block_sz",
+            "title" : "Drive Model",
             "type" : "integer"
           },
           "required" : [
             "_default"
           ],
+          "title" : "Disk Size",
           "type" : "object"
         }
       },

--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -413,27 +413,45 @@
       "minProperties" : 1,
       "properties" : {
         "alias" : {
-          "$ref" : "common.json#/$defs/mojo_standard_placeholder"
+          "$ref" : "common.json#/$defs/mojo_standard_placeholder",
+          "title" : "Alias"
         },
         "bios_firmware" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "BIOS Firmware",
           "type" : "string"
         },
         "cpu_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of CPUs",
           "type" : "integer"
         },
         "cpu_type" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "CPU Type",
           "type" : "string"
         },
         "dimms_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of DIMMs",
           "type" : "integer"
         },
         "generation_name" : {
-          "$ref" : "common.json#/$defs/non_empty_string"
+          "$ref" : "common.json#/$defs/non_empty_string",
+          "title" : "Generation Name"
         },
         "hardware_vendor_id" : {
-          "$ref" : "common.json#/$defs/uuid"
+          "$ref" : "common.json#/$defs/uuid",
+          "title" : "Hardware Vendor ID"
         },
         "hba_firmware" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "HBA Firmware",
           "type" : [
             "null",
             "string"
@@ -447,24 +465,38 @@
             {
               "type" : "null"
             }
-          ]
+          ],
+          "title" : "Legacy Product Name"
         },
         "name" : {
-          "$ref" : "common.json#/$defs/mojo_standard_placeholder"
+          "$ref" : "common.json#/$defs/mojo_standard_placeholder",
+          "title" : "Name"
         },
         "nics_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of NICs",
           "type" : "integer"
         },
         "nvme_ssd_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of SAS HDDs",
           "type" : "integer"
         },
         "nvme_ssd_size" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "NVME SSD Size",
           "type" : [
             "null",
             "integer"
           ]
         },
         "nvme_ssd_slots" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "NVME SSD Slots",
           "type" : [
             "null",
             "string"
@@ -478,85 +510,134 @@
             {
               "type" : "null"
             }
-          ]
+          ],
+          "title" : "Prefix"
         },
         "psu_total" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "PSU Total",
           "type" : "integer"
         },
         "purpose" : {
+          "title" : "Purpose",
           "type" : "string"
         },
         "rack_unit_size" : {
-          "$ref" : "common.json#/$defs/positive_integer"
+          "$ref" : "common.json#/$defs/positive_integer",
+          "title" : "Rack Unit Size (RU)"
         },
         "raid_lun_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of RAID LUNs",
           "type" : "integer"
         },
         "ram_total" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "RAM Total",
           "type" : "integer"
         },
         "sas_hdd_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of SAS HDDs",
           "type" : "integer"
         },
         "sas_hdd_size" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "SAS HDD Size",
           "type" : [
             "null",
             "integer"
           ]
         },
         "sas_hdd_slots" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "SAS HDD Slots",
           "type" : [
             "null",
             "string"
           ]
         },
         "sas_ssd_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of SSD SSDs",
           "type" : "integer"
         },
         "sas_ssd_size" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "SAS SSD Size",
           "type" : [
             "null",
             "integer"
           ]
         },
         "sas_ssd_slots" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "SAS SSD Slots",
           "type" : [
             "null",
             "string"
           ]
         },
         "sata_hdd_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of SATA HDDs",
           "type" : "integer"
         },
         "sata_hdd_size" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "SATA HDD Size",
           "type" : [
             "null",
             "integer"
           ]
         },
         "sata_hdd_slots" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "SATA HDD Slots",
           "type" : [
             "null",
             "string"
           ]
         },
         "sata_ssd_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of SATA SSDs",
           "type" : "integer"
         },
         "sata_ssd_size" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "SATA SSD Size",
           "type" : [
             "null",
             "integer"
           ]
         },
         "sata_ssd_slots" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "SATA SSD Slots",
           "type" : [
             "null",
             "string"
           ]
         },
         "sku" : {
-          "$ref" : "common.json#/$defs/mojo_standard_placeholder"
+          "$ref" : "common.json#/$defs/mojo_standard_placeholder",
+          "title" : "SKU"
         },
         "specification" : {
           "oneOf" : [
@@ -566,15 +647,20 @@
             {
               "type" : "null"
             }
-          ]
+          ],
+          "title" : "Specification"
         },
         "usb_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of USBs",
           "type" : "integer"
         },
         "validation_plan_id" : {
           "$comment" : "this property will become nullable in v3.3 and removed in v4.0",
           "$ref" : "common.json#/$defs/uuid",
-          "deprecated" : true
+          "deprecated" : true,
+          "title" : "Validation Plan ID"
         }
       },
       "type" : "object"

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -1217,152 +1217,237 @@
       "additionalProperties" : false,
       "properties" : {
         "alias" : {
-          "$ref" : "common.json#/$defs/mojo_standard_placeholder"
+          "$ref" : "common.json#/$defs/mojo_standard_placeholder",
+          "title" : "Alias"
         },
         "bios_firmware" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "BIOS Firmware",
           "type" : "string"
         },
         "cpu_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of CPUs",
           "type" : "integer"
         },
         "cpu_type" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "CPU Type",
           "type" : "string"
         },
         "created" : {
           "format" : "date-time",
+          "readOnly" : true,
+          "title" : "Created",
           "type" : "string"
         },
         "dimms_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of DIMMs",
           "type" : "integer"
         },
         "generation_name" : {
+          "title" : "Generation Name",
           "type" : [
             "null",
             "string"
           ]
         },
         "hardware_vendor_id" : {
-          "$ref" : "common.json#/$defs/uuid"
+          "$ref" : "common.json#/$defs/uuid",
+          "title" : "Hardware Vendor ID"
         },
         "hba_firmware" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "HBA Firmware",
           "type" : [
             "null",
             "string"
           ]
         },
         "id" : {
-          "$ref" : "common.json#/$defs/uuid"
+          "$ref" : "common.json#/$defs/uuid",
+          "readOnly" : true,
+          "title" : "ID"
         },
         "legacy_product_name" : {
+          "title" : "Legacy Product Name",
           "type" : [
             "null",
             "string"
           ]
         },
         "name" : {
-          "$ref" : "common.json#/$defs/mojo_standard_placeholder"
+          "$ref" : "common.json#/$defs/mojo_standard_placeholder",
+          "title" : "Name"
         },
         "nics_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of NICs",
           "type" : "integer"
         },
         "nvme_ssd_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of SAS HDDs",
           "type" : "integer"
         },
         "nvme_ssd_size" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "NVME SSD Size",
           "type" : [
             "null",
             "integer"
           ]
         },
         "nvme_ssd_slots" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "NVME SSD Slots",
           "type" : [
             "null",
             "string"
           ]
         },
         "prefix" : {
+          "title" : "Prefix",
           "type" : [
             "null",
             "string"
           ]
         },
         "psu_total" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "PSU Total",
           "type" : "integer"
         },
         "purpose" : {
+          "title" : "Purpose",
           "type" : "string"
         },
         "rack_unit_size" : {
-          "$ref" : "common.json#/$defs/positive_integer"
+          "$ref" : "common.json#/$defs/positive_integer",
+          "title" : "Rack Unit Size (RU)"
         },
         "raid_lun_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of RAID LUNs",
           "type" : "integer"
         },
         "ram_total" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "RAM Total",
           "type" : "integer"
         },
         "sas_hdd_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of SAS HDDs",
           "type" : "integer"
         },
         "sas_hdd_size" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "SAS HDD Size",
           "type" : [
             "null",
             "integer"
           ]
         },
         "sas_hdd_slots" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "SAS HDD Slots",
           "type" : [
             "null",
             "string"
           ]
         },
         "sas_ssd_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of SSD SSDs",
           "type" : "integer"
         },
         "sas_ssd_size" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "SAS SSD Size",
           "type" : [
             "null",
             "integer"
           ]
         },
         "sas_ssd_slots" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "SAS SSD Slots",
           "type" : [
             "null",
             "string"
           ]
         },
         "sata_hdd_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of SATA HDDs",
           "type" : "integer"
         },
         "sata_hdd_size" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "SATA HDD Size",
           "type" : [
             "null",
             "integer"
           ]
         },
         "sata_hdd_slots" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "SATA HDD Slots",
           "type" : [
             "null",
             "string"
           ]
         },
         "sata_ssd_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of SATA SSDs",
           "type" : "integer"
         },
         "sata_ssd_size" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "SATA SSD Size",
           "type" : [
             "null",
             "integer"
           ]
         },
         "sata_ssd_slots" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "SATA SSD Slots",
           "type" : [
             "null",
             "string"
           ]
         },
         "sku" : {
-          "$ref" : "common.json#/$defs/mojo_standard_placeholder"
+          "$ref" : "common.json#/$defs/mojo_standard_placeholder",
+          "title" : "SKU"
         },
         "specification" : {
           "oneOf" : [
@@ -1372,19 +1457,26 @@
             {
               "type" : "null"
             }
-          ]
+          ],
+          "title" : "Specification"
         },
         "updated" : {
           "format" : "date-time",
+          "readOnly" : true,
+          "title" : "Updated",
           "type" : "string"
         },
         "usb_num" : {
+          "$comment" : "this property will be moved into /specification in v3.2",
+          "deprecated" : true,
+          "title" : "Number of USBs",
           "type" : "integer"
         },
         "validation_plan_id" : {
           "$comment" : "this property will become nullable in v3.3 and removed in v4.0",
           "$ref" : "common.json#/$defs/uuid",
-          "deprecated" : true
+          "deprecated" : true,
+          "title" : "Validation Plan ID"
         }
       },
       "required" : [

--- a/json-schema/common.yaml
+++ b/json-schema/common.yaml
@@ -82,24 +82,30 @@ $defs:
       type: string
       format: uri
   HardwareProductSpecification:
-    $comment: this is the structure of the hardware_product.specification database column
+    $comment: 'this is the structure of the hardware_product.specification database column. NOTE: by conch api v3.2 this schema will be in the json_schema table in the database (available via GET /json_schema/hardware_product/specification/latest) so it can be updated dynamically'
+    deprecated: true
     type: object
     additionalProperties: true  # there is all kinds of junk in here still
     properties:
       disk_size:
+        title: Disk Size
         type: object
         $comment: property names correspond to device report /disks/<disk serial>/model
         required: [ _default ]
         additionalProperties:
+          title: Drive Model
           $comment: property values are compared to device report /disks/<disk serial>/block_sz
           type: integer
       chassis:
+        title: Chassis
         type: object
         properties:
           memory:
+            title: Memory
             type: object
             properties:
               dimms:
+                title: DIMMs
                 $comment: items are in slot order, as in device report /dimms/*
                 type: array
                 minItems: 1

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -243,84 +243,170 @@ $defs:
     minProperties: 1
     properties:
       name:
+        title: Name
         $ref: common.yaml#/$defs/mojo_standard_placeholder
       alias:
+        title: Alias
         $ref: common.yaml#/$defs/mojo_standard_placeholder
       prefix:
+        title: Prefix
         oneOf:
           - $ref: common.yaml#/$defs/non_empty_string
           - type: 'null'
       hardware_vendor_id:
+        title: Hardware Vendor ID
         $ref: common.yaml#/$defs/uuid
       specification:
+        title: Specification
         oneOf:
           - $ref: common.yaml#/$defs/HardwareProductSpecification
           - type: 'null'
       sku:
+        title: SKU
         $ref: common.yaml#/$defs/mojo_standard_placeholder
       generation_name:
+        title: Generation Name
         $ref: common.yaml#/$defs/non_empty_string
       legacy_product_name:
+        title: Legacy Product Name
         oneOf:
           - $ref: common.yaml#/$defs/non_empty_string
           - type: 'null'
       rack_unit_size:
+        title: Rack Unit Size (RU)
         $ref: common.yaml#/$defs/positive_integer
       validation_plan_id:
         $comment: this property will become nullable in v3.3 and removed in v4.0
         deprecated: true
+        title: Validation Plan ID
         $ref: common.yaml#/$defs/uuid
       purpose:
         type: string
+        title: Purpose
       bios_firmware:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: BIOS Firmware
         type: string
       hba_firmware:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: HBA Firmware
         type: [ 'null', string ]
       cpu_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of CPUs
         type: integer
       cpu_type:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: CPU Type
         type: string
       dimms_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of DIMMs
         type: integer
       ram_total:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: RAM Total
         type: integer
       nics_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of NICs
         type: integer
       sata_hdd_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of SATA HDDs
         type: integer
       sata_hdd_size:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: SATA HDD Size
         type: [ 'null', integer ]
       sata_hdd_slots:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: SATA HDD Slots
         type: [ 'null', string ]
       sas_hdd_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of SAS HDDs
         type: integer
       sas_hdd_size:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: SAS HDD Size
         type: [ 'null', integer ]
       sas_hdd_slots:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: SAS HDD Slots
         type: [ 'null', string ]
       sata_ssd_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of SATA SSDs
         type: integer
       sata_ssd_size:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: SATA SSD Size
         type: [ 'null', integer ]
       sata_ssd_slots:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: SATA SSD Slots
         type: [ 'null', string ]
       sas_ssd_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of SSD SSDs
         type: integer
       sas_ssd_size:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: SAS SSD Size
         type: [ 'null', integer ]
       sas_ssd_slots:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: SAS SSD Slots
         type: [ 'null', string ]
       nvme_ssd_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of SAS HDDs
         type: integer
       nvme_ssd_size:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: NVME SSD Size
         type: [ 'null', integer ]
       nvme_ssd_slots:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: NVME SSD Slots
         type: [ 'null', string ]
       raid_lun_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of RAID LUNs
         type: integer
       psu_total:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: PSU Total
         type: integer
       usb_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of USBs
         type: integer
   Login:
     type: object

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -627,88 +627,180 @@ $defs:
       - usb_num
     properties:
       id:
+        title: ID
+        readOnly: true
         $ref: common.yaml#/$defs/uuid
       name:
+        title: Name
         $ref: common.yaml#/$defs/mojo_standard_placeholder
       alias:
+        title: Alias
         $ref: common.yaml#/$defs/mojo_standard_placeholder
       prefix:
+        title: Prefix
         type: [ 'null', string ]
       hardware_vendor_id:
+        title: Hardware Vendor ID
         $ref: common.yaml#/$defs/uuid
       generation_name:
+        title: Generation Name
         type: [ 'null', string ]
       legacy_product_name:
+        title: Legacy Product Name
         type: [ 'null', string ]
       sku:
+        title: SKU
         $ref: common.yaml#/$defs/mojo_standard_placeholder
       specification:
+        title: Specification
         oneOf:
           - $ref: common.yaml#/$defs/HardwareProductSpecification
           - type: 'null'
       rack_unit_size:
+        title: Rack Unit Size (RU)
         $ref: common.yaml#/$defs/positive_integer
       created:
+        title: Created
+        readOnly: true
         type: string
         format: date-time
       updated:
+        title: Updated
+        readOnly: true
         type: string
         format: date-time
       validation_plan_id:
         $comment: this property will become nullable in v3.3 and removed in v4.0
         deprecated: true
+        title: Validation Plan ID
         $ref: common.yaml#/$defs/uuid
       bios_firmware:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: BIOS Firmware
         type: string
       cpu_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of CPUs
         type: integer
       cpu_type:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: CPU Type
         type: string
       dimms_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of DIMMs
         type: integer
       hba_firmware:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: HBA Firmware
         type: [ 'null', string ]
       nics_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of NICs
         type: integer
       psu_total:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: PSU Total
         type: integer
       purpose:
+        title: Purpose
         type: string
       ram_total:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: RAM Total
         type: integer
       sas_hdd_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of SAS HDDs
         type: integer
       sas_hdd_size:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: SAS HDD Size
         type: [ 'null', integer ]
       sas_hdd_slots:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: SAS HDD Slots
         type: [ 'null', string ]
       sata_hdd_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of SATA HDDs
         type: integer
       sata_hdd_size:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: SATA HDD Size
         type: [ 'null', integer ]
       sata_hdd_slots:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: SATA HDD Slots
         type: [ 'null', string ]
       sata_ssd_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of SATA SSDs
         type: integer
       sata_ssd_size:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: SATA SSD Size
         type: [ 'null', integer ]
       sata_ssd_slots:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: SATA SSD Slots
         type: [ 'null', string ]
       sas_ssd_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of SSD SSDs
         type: integer
       sas_ssd_size:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: SAS SSD Size
         type: [ 'null', integer ]
       sas_ssd_slots:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: SAS SSD Slots
         type: [ 'null', string ]
       nvme_ssd_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of SAS HDDs
         type: integer
       nvme_ssd_size:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: NVME SSD Size
         type: [ 'null', integer ]
       nvme_ssd_slots:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: NVME SSD Slots
         type: [ 'null', string ]
       raid_lun_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of RAID LUNs
         type: integer
       usb_num:
+        $comment: this property will be moved into /specification in v3.2
+        deprecated: true
+        title: Number of USBs
         type: integer
   LegacyValidations:
     $comment: this definition will be removed in v4.0

--- a/lib/Conch/Route/JSONSchema.pm
+++ b/lib/Conch/Route/JSONSchema.pm
@@ -37,6 +37,10 @@ sub unsecured_routes ($class, $js) {
     $js->get('/:json_schema_type/<json_schema_name:json_pointer_token>',
             [ json_schema_type => [qw(query_params request response common device_report)] ])
         ->to('#get', response_schema => 'JSONSchemaOnDisk');
+
+    # TODO: this will become secured in v3.2, and handled directly instead of by redirect.
+    $js->get('/hardware_product/specification/latest',
+      sub ($c) { $c->status(307, '/json_schema/common/HardwareProductSpecification') });
 }
 
 1;

--- a/t/integration/json_schema-unauthed.t
+++ b/t/integration/json_schema-unauthed.t
@@ -176,6 +176,10 @@ $t->get_ok('/json_schema/request/HardwareProductCreate')
         },
     }), 'nested definitions are found and included');
 
+$t->get_ok('/json_schema/hardware_product/specification/latest')
+    ->status_is(307)
+    ->location_is('/json_schema/common/HardwareProductSpecification');
+
 $t->get_ok('/json_schema/response/JSONSchemaOnDisk')
     ->status_is(200)
     ->header_is('Content-Type', 'application/schema+json')


### PR DESCRIPTION
- add titles for all hardware_product properties, for requests and responses
    
..and readOnly on properties in responses that cannot be provided in requests.
Also noted is that many properties are slated to be moved by v3.2.

- handle GET /json_schema/hardware_product/specification/latest
    
By v3.2 this will be handled directly by the get-schema-from-database endpoint and the content will
be dynamic; for now, just redirect to the endpoint which fetches the schema from disk.

