### PR TITLE
v3.1.1 fixes

### DIFF
--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -481,7 +481,7 @@
         "nvme_ssd_num" : {
           "$comment" : "this property will be moved into /specification in v3.2",
           "deprecated" : true,
-          "title" : "Number of SAS HDDs",
+          "title" : "Number of NVME SSDs",
           "type" : "integer"
         },
         "nvme_ssd_size" : {
@@ -566,7 +566,7 @@
         "sas_ssd_num" : {
           "$comment" : "this property will be moved into /specification in v3.2",
           "deprecated" : true,
-          "title" : "Number of SSD SSDs",
+          "title" : "Number of SAS SSDs",
           "type" : "integer"
         },
         "sas_ssd_size" : {

--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -640,14 +640,7 @@
           "title" : "SKU"
         },
         "specification" : {
-          "oneOf" : [
-            {
-              "$ref" : "common.json#/$defs/HardwareProductSpecification"
-            },
-            {
-              "type" : "null"
-            }
-          ],
+          "$ref" : "common.json#/$defs/HardwareProductSpecification",
           "title" : "Specification"
         },
         "usb_num" : {

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -1295,7 +1295,7 @@
         "nvme_ssd_num" : {
           "$comment" : "this property will be moved into /specification in v3.2",
           "deprecated" : true,
-          "title" : "Number of SAS HDDs",
+          "title" : "Number of NVME SSDs",
           "type" : "integer"
         },
         "nvme_ssd_size" : {
@@ -1376,7 +1376,7 @@
         "sas_ssd_num" : {
           "$comment" : "this property will be moved into /specification in v3.2",
           "deprecated" : true,
-          "title" : "Number of SSD SSDs",
+          "title" : "Number of SAS SSDs",
           "type" : "integer"
         },
         "sas_ssd_size" : {

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -1450,14 +1450,7 @@
           "title" : "SKU"
         },
         "specification" : {
-          "oneOf" : [
-            {
-              "$ref" : "common.json#/$defs/HardwareProductSpecification"
-            },
-            {
-              "type" : "null"
-            }
-          ],
+          "$ref" : "common.json#/$defs/HardwareProductSpecification",
           "title" : "Specification"
         },
         "updated" : {

--- a/docs/modules/Conch::DB::Result::HardwareProduct.md
+++ b/docs/modules/Conch::DB::Result::HardwareProduct.md
@@ -78,7 +78,8 @@ original: {default_value => \"now()"}
 
 ```
 data_type: 'jsonb'
-is_nullable: 1
+default_value: '{}'
+is_nullable: 0
 ```
 
 ### sku

--- a/docs/modules/Conch::Route::JSONSchema.md
+++ b/docs/modules/Conch::Route::JSONSchema.md
@@ -30,6 +30,16 @@ requests and responses.
 - Response: a JSON Schema ([response.json#/$defs/JSONSchemaOnDisk](../json-schema/response.json#/$defs/JSONSchemaOnDisk)) (Content-Type is
 `application/schema+json`).
 
+### `GET /json_schema/hardware_product/specification/latest`
+
+Fetches the JSON Schema document used for describing the structure of the `specification`
+column of the `hardware_product` database table.
+
+Note: this is a special case of a generic endpoint to be added in Conch API version 3.2.
+In the future, it will be modifiable; attempted modifications of this schema will be verified
+against all existing `hardware_product.specification` data, and any attempted modifications to
+specification data will be verified against this schema.
+
 ## LICENSING
 
 Copyright Joyent, Inc.

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -258,9 +258,7 @@ $defs:
         $ref: common.yaml#/$defs/uuid
       specification:
         title: Specification
-        oneOf:
-          - $ref: common.yaml#/$defs/HardwareProductSpecification
-          - type: 'null'
+        $ref: common.yaml#/$defs/HardwareProductSpecification
       sku:
         title: SKU
         $ref: common.yaml#/$defs/mojo_standard_placeholder

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -366,7 +366,7 @@ $defs:
       sas_ssd_num:
         $comment: this property will be moved into /specification in v3.2
         deprecated: true
-        title: Number of SSD SSDs
+        title: Number of SAS SSDs
         type: integer
       sas_ssd_size:
         $comment: this property will be moved into /specification in v3.2
@@ -381,7 +381,7 @@ $defs:
       nvme_ssd_num:
         $comment: this property will be moved into /specification in v3.2
         deprecated: true
-        title: Number of SAS HDDs
+        title: Number of NVME SSDs
         type: integer
       nvme_ssd_size:
         $comment: this property will be moved into /specification in v3.2

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -766,7 +766,7 @@ $defs:
       sas_ssd_num:
         $comment: this property will be moved into /specification in v3.2
         deprecated: true
-        title: Number of SSD SSDs
+        title: Number of SAS SSDs
         type: integer
       sas_ssd_size:
         $comment: this property will be moved into /specification in v3.2
@@ -781,7 +781,7 @@ $defs:
       nvme_ssd_num:
         $comment: this property will be moved into /specification in v3.2
         deprecated: true
-        title: Number of SAS HDDs
+        title: Number of NVME SSDs
         type: integer
       nvme_ssd_size:
         $comment: this property will be moved into /specification in v3.2

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -654,9 +654,7 @@ $defs:
         $ref: common.yaml#/$defs/mojo_standard_placeholder
       specification:
         title: Specification
-        oneOf:
-          - $ref: common.yaml#/$defs/HardwareProductSpecification
-          - type: 'null'
+        $ref: common.yaml#/$defs/HardwareProductSpecification
       rack_unit_size:
         title: Rack Unit Size (RU)
         $ref: common.yaml#/$defs/positive_integer

--- a/lib/Conch/Controller/JSONSchema.pm
+++ b/lib/Conch/Controller/JSONSchema.pm
@@ -86,6 +86,12 @@ sub get ($c) {
     $bundled_schema->{'$id'} = $c->url_for('/json_schema/'.$type.'/'.$name)->to_abs;
     $bundled_schema->{'$schema'} //= 'https://json-schema.org/draft/2019-09/schema';
 
+    # hack! remove when adding get-from-database functionality
+    if ($c->req->url->path =~ qr{^/json_schema/hardware_product/specification/(?:1|latest)$}) {
+        $bundled_schema->{'$id'} = $c->url_for->path('1')->to_abs;
+        delete $bundled_schema->{deprecated};
+    }
+
     $c->res->headers->content_type('application/schema+json');
     return $c->status(200, $bundled_schema);
 }

--- a/lib/Conch/DB/Result/HardwareProduct.pm
+++ b/lib/Conch/DB/Result/HardwareProduct.pm
@@ -79,7 +79,8 @@ __PACKAGE__->table("hardware_product");
 =head2 specification
 
   data_type: 'jsonb'
-  is_nullable: 1
+  default_value: '{}'
+  is_nullable: 0
 
 =head2 sku
 
@@ -285,7 +286,7 @@ __PACKAGE__->add_columns(
     original      => { default_value => \"now()" },
   },
   "specification",
-  { data_type => "jsonb", is_nullable => 1 },
+  { data_type => "jsonb", default_value => "{}", is_nullable => 0 },
   "sku",
   { data_type => "text", is_nullable => 0 },
   "generation_name",
@@ -441,7 +442,7 @@ __PACKAGE__->has_many(
 
 
 # Created by DBIx::Class::Schema::Loader v0.07049
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:9Q3v8Ag2aFFkitFegf0t2g
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:jh81nspu+x8IBhfHU063jQ
 
 use experimental 'signatures';
 use Mojo::JSON 'from_json';

--- a/lib/Conch/Route/JSONSchema.pm
+++ b/lib/Conch/Route/JSONSchema.pm
@@ -38,9 +38,11 @@ sub unsecured_routes ($class, $js) {
             [ json_schema_type => [qw(query_params request response common device_report)] ])
         ->to('#get', response_schema => 'JSONSchemaOnDisk');
 
-    # TODO: this will become secured in v3.2, and handled directly instead of by redirect.
-    $js->get('/hardware_product/specification/latest',
-      sub ($c) { $c->status(307, '/json_schema/common/HardwareProductSpecification') });
+    # TODO: this will become secured in v3.2, and handled directly by the main 'get' endpoint
+    $js->get('/hardware_product/specification/:json_schema_version',
+        { json_schema_version => qr/(?:1|latest)/ })
+      ->to('#get', json_schema_type => 'common', json_schema_name => 'HardwareProductSpecification',
+          response_schema => 'JSONSchemaOnDisk');
 }
 
 1;
@@ -73,6 +75,16 @@ requests and responses.
 C<application/schema+json>).
 
 =back
+
+=head2 C<GET /json_schema/hardware_product/specification/latest>
+
+Fetches the JSON Schema document used for describing the structure of the C<specification>
+column of the C<hardware_product> database table.
+
+Note: this is a special case of a generic endpoint to be added in Conch API version 3.2.
+In the future, it will be modifiable; attempted modifications of this schema will be verified
+against all existing C<hardware_product.specification> data, and any attempted modifications to
+specification data will be verified against this schema.
 
 =head1 LICENSING
 

--- a/sql/migrations/0179-hardware_product-specification-not-null.sql
+++ b/sql/migrations/0179-hardware_product-specification-not-null.sql
@@ -1,0 +1,8 @@
+SELECT run_migration(179, $$
+
+  update hardware_product set specification = '{}' where specification is null;
+
+  alter table hardware_product alter column specification set default '{}',
+    alter column specification set not null;
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -380,7 +380,7 @@ CREATE TABLE public.hardware_product (
     deactivated timestamp with time zone,
     created timestamp with time zone DEFAULT now() NOT NULL,
     updated timestamp with time zone DEFAULT now() NOT NULL,
-    specification jsonb,
+    specification jsonb DEFAULT '{}'::jsonb NOT NULL,
     sku text NOT NULL,
     generation_name text,
     legacy_product_name text,

--- a/t/integration/json_schema-unauthed.t
+++ b/t/integration/json_schema-unauthed.t
@@ -176,9 +176,20 @@ $t->get_ok('/json_schema/request/HardwareProductCreate')
         },
     }), 'nested definitions are found and included');
 
-$t->get_ok('/json_schema/hardware_product/specification/latest')
-    ->status_is(307)
-    ->location_is('/json_schema/common/HardwareProductSpecification');
+$t->get_ok('/json_schema/hardware_product/specification/'.$_)
+    ->status_is(200)
+    ->header_is('Content-Type', 'application/schema+json')
+    ->json_schema_is('JSONSchemaOnDisk')
+    ->json_cmp_deeply({
+        '$schema' => SPEC_URL,
+        '$id' => $base_uri.'json_schema/hardware_product/specification/1',
+        '$comment' => ignore,
+        # no deprecated!
+        type => 'object',
+        additionalProperties => bool(1),
+        properties => superhashof({}),
+      })
+    foreach qw(latest 1);
 
 $t->get_ok('/json_schema/response/JSONSchemaOnDisk')
     ->status_is(200)


### PR DESCRIPTION
- fix titles for these specification fields
- make the temporary hack endpoint (for hardware_product.specification) work exactly like its real replacement will
- make hardware_product.specification not nullable
