### PR TITLE
infer data from device reports to populate hardware product

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -35,7 +35,7 @@ requires 'YAML::PP';
 requires 'next::XS';
 
 # mojolicious and networking
-requires 'Mojolicious', '8.36';
+requires 'Mojolicious', '8.50';
 requires 'Mojo::Pg';
 requires 'Mojo::JWT';
 requires 'Mojolicious::Plugin::Util::RandomString', '0.07'; # memory leak: https://rt.cpan.org/Ticket/Display.html?id=125981

--- a/docs/json-schema/device_report.json
+++ b/docs/json-schema/device_report.json
@@ -1,7 +1,7 @@
 {
   "$comment" : "NOTE: This file is for human reference ONLY. For programmatic use, use the GET '/json_schema/device_report/$schema_name' endpoints, or within conch itself, json-schema/device_report.yaml.",
   "$defs" : {
-    "DeviceReport_v3_0_0" : {
+    "DeviceReport_v3_2_0" : {
       "$comment" : "the contents of a posted device report from relays and reporters",
       "additionalProperties" : true,
       "properties" : {
@@ -192,6 +192,11 @@
           ],
           "type" : "object"
         },
+        "report_version" : {
+          "$comment" : "future conch-api versions MAY be backwards-compatible to previous report versions, but this is not guaranteed",
+          "const" : "v3.2",
+          "type" : "string"
+        },
         "serial_number" : {
           "$ref" : "common.json#/$defs/device_serial_number"
         },
@@ -227,6 +232,7 @@
         }
       },
       "required" : [
+        "report_version",
         "bios_version",
         "product_name",
         "sku",

--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -428,25 +428,25 @@
           "title" : "Alias"
         },
         "bios_firmware" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "BIOS Firmware",
           "type" : "string"
         },
         "cpu_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of CPUs",
           "type" : "integer"
         },
         "cpu_type" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "CPU Type",
           "type" : "string"
         },
         "dimms_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of DIMMs",
           "type" : "integer"
@@ -460,7 +460,7 @@
           "title" : "Hardware Vendor ID"
         },
         "hba_firmware" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "HBA Firmware",
           "type" : [
@@ -484,19 +484,19 @@
           "title" : "Name"
         },
         "nics_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of NICs",
           "type" : "integer"
         },
         "nvme_ssd_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of NVME SSDs",
           "type" : "integer"
         },
         "nvme_ssd_size" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "NVME SSD Size",
           "type" : [
@@ -505,7 +505,7 @@
           ]
         },
         "nvme_ssd_slots" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "NVME SSD Slots",
           "type" : [
@@ -525,7 +525,7 @@
           "title" : "Prefix"
         },
         "psu_total" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "PSU Total",
           "type" : "integer"
@@ -539,25 +539,25 @@
           "title" : "Rack Unit Size (RU)"
         },
         "raid_lun_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of RAID LUNs",
           "type" : "integer"
         },
         "ram_total" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "RAM Total",
           "type" : "integer"
         },
         "sas_hdd_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of SAS HDDs",
           "type" : "integer"
         },
         "sas_hdd_size" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "SAS HDD Size",
           "type" : [
@@ -566,7 +566,7 @@
           ]
         },
         "sas_hdd_slots" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "SAS HDD Slots",
           "type" : [
@@ -575,13 +575,13 @@
           ]
         },
         "sas_ssd_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of SAS SSDs",
           "type" : "integer"
         },
         "sas_ssd_size" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "SAS SSD Size",
           "type" : [
@@ -590,7 +590,7 @@
           ]
         },
         "sas_ssd_slots" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "SAS SSD Slots",
           "type" : [
@@ -599,13 +599,13 @@
           ]
         },
         "sata_hdd_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of SATA HDDs",
           "type" : "integer"
         },
         "sata_hdd_size" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "SATA HDD Size",
           "type" : [
@@ -614,7 +614,7 @@
           ]
         },
         "sata_hdd_slots" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "SATA HDD Slots",
           "type" : [
@@ -623,13 +623,13 @@
           ]
         },
         "sata_ssd_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of SATA SSDs",
           "type" : "integer"
         },
         "sata_ssd_size" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "SATA SSD Size",
           "type" : [
@@ -638,7 +638,7 @@
           ]
         },
         "sata_ssd_slots" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "SATA SSD Slots",
           "type" : [
@@ -656,7 +656,7 @@
           "type" : "object"
         },
         "usb_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of USBs",
           "type" : "integer"

--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -400,8 +400,7 @@
         "rack_unit_size",
         "validation_plan_id",
         "purpose",
-        "bios_firmware",
-        "cpu_type"
+        "bios_firmware"
       ]
     },
     "HardwareProductUpdate" : {

--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -368,7 +368,7 @@
       "type" : "object"
     },
     "DeviceReport" : {
-      "$ref" : "device_report.json#/$defs/DeviceReport_v3_0_0"
+      "$ref" : "device_report.json#/$defs/DeviceReport_v3_2_0"
     },
     "DeviceSetting" : {
       "$ref" : "#/$defs/DeviceSettings",

--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -406,6 +406,21 @@
     },
     "HardwareProductUpdate" : {
       "additionalProperties" : false,
+      "default" : {
+        "cpu_num" : 0,
+        "dimms_num" : 0,
+        "nics_num" : 0,
+        "nvme_ssd_num" : 0,
+        "psu_total" : 0,
+        "raid_lun_num" : 0,
+        "ram_total" : 0,
+        "sas_hdd_num" : 0,
+        "sas_ssd_num" : 0,
+        "sata_hdd_num" : 0,
+        "sata_ssd_num" : 0,
+        "specification" : {},
+        "usb_num" : 0
+      },
       "minProperties" : 1,
       "properties" : {
         "alias" : {

--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -392,15 +392,26 @@
     },
     "HardwareProductCreate" : {
       "$ref" : "#/$defs/HardwareProductUpdate",
+      "anyOf" : [
+        {
+          "required" : [
+            "name",
+            "sku",
+            "validation_plan_id",
+            "bios_firmware"
+          ]
+        },
+        {
+          "required" : [
+            "device_report"
+          ]
+        }
+      ],
       "required" : [
-        "name",
         "alias",
         "hardware_vendor_id",
-        "sku",
         "rack_unit_size",
-        "validation_plan_id",
-        "purpose",
-        "bios_firmware"
+        "purpose"
       ]
     },
     "HardwareProductUpdate" : {
@@ -443,6 +454,10 @@
           "deprecated" : true,
           "title" : "CPU Type",
           "type" : "string"
+        },
+        "device_report" : {
+          "$ref" : "device_report.json#/$defs/DeviceReport_v3_2_0",
+          "title" : "Sample passing device report"
         },
         "dimms_num" : {
           "$comment" : "this property will be moved into /specification in v3.4",

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -1302,19 +1302,19 @@
           "title" : "Alias"
         },
         "bios_firmware" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "BIOS Firmware",
           "type" : "string"
         },
         "cpu_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of CPUs",
           "type" : "integer"
         },
         "cpu_type" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "CPU Type",
           "type" : "string"
@@ -1326,7 +1326,7 @@
           "type" : "string"
         },
         "dimms_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of DIMMs",
           "type" : "integer"
@@ -1343,7 +1343,7 @@
           "title" : "Hardware Vendor ID"
         },
         "hba_firmware" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "HBA Firmware",
           "type" : [
@@ -1368,19 +1368,19 @@
           "title" : "Name"
         },
         "nics_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of NICs",
           "type" : "integer"
         },
         "nvme_ssd_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of NVME SSDs",
           "type" : "integer"
         },
         "nvme_ssd_size" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "NVME SSD Size",
           "type" : [
@@ -1389,7 +1389,7 @@
           ]
         },
         "nvme_ssd_slots" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "NVME SSD Slots",
           "type" : [
@@ -1405,7 +1405,7 @@
           ]
         },
         "psu_total" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "PSU Total",
           "type" : "integer"
@@ -1419,25 +1419,25 @@
           "title" : "Rack Unit Size (RU)"
         },
         "raid_lun_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of RAID LUNs",
           "type" : "integer"
         },
         "ram_total" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "RAM Total",
           "type" : "integer"
         },
         "sas_hdd_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of SAS HDDs",
           "type" : "integer"
         },
         "sas_hdd_size" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "SAS HDD Size",
           "type" : [
@@ -1446,7 +1446,7 @@
           ]
         },
         "sas_hdd_slots" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "SAS HDD Slots",
           "type" : [
@@ -1455,13 +1455,13 @@
           ]
         },
         "sas_ssd_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of SAS SSDs",
           "type" : "integer"
         },
         "sas_ssd_size" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "SAS SSD Size",
           "type" : [
@@ -1470,7 +1470,7 @@
           ]
         },
         "sas_ssd_slots" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "SAS SSD Slots",
           "type" : [
@@ -1479,13 +1479,13 @@
           ]
         },
         "sata_hdd_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of SATA HDDs",
           "type" : "integer"
         },
         "sata_hdd_size" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "SATA HDD Size",
           "type" : [
@@ -1494,7 +1494,7 @@
           ]
         },
         "sata_hdd_slots" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "SATA HDD Slots",
           "type" : [
@@ -1503,13 +1503,13 @@
           ]
         },
         "sata_ssd_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of SATA SSDs",
           "type" : "integer"
         },
         "sata_ssd_size" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "SATA SSD Size",
           "type" : [
@@ -1518,7 +1518,7 @@
           ]
         },
         "sata_ssd_slots" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "SATA SSD Slots",
           "type" : [
@@ -1542,7 +1542,7 @@
           "type" : "string"
         },
         "usb_num" : {
-          "$comment" : "this property will be moved into /specification in v3.2",
+          "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "Number of USBs",
           "type" : "integer"

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -1317,7 +1317,10 @@
           "$comment" : "this property will be moved into /specification in v3.4",
           "deprecated" : true,
           "title" : "CPU Type",
-          "type" : "string"
+          "type" : [
+            "null",
+            "string"
+          ]
         },
         "created" : {
           "format" : "date-time",

--- a/docs/modules/Conch::Controller::HardwareProduct.md
+++ b/docs/modules/Conch::Controller::HardwareProduct.md
@@ -61,6 +61,11 @@ the schema at `/json_schema/hardware_product/specification/latest`.
 
 ### remove\_all\_json\_schemas
 
+### extract\_from\_device\_report
+
+If a sample device report is provided in the payload, use its contents to extrapolate some values
+for `hardware_product`.
+
 ## LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::DB::Result::HardwareProduct.md
+++ b/docs/modules/Conch::DB::Result::HardwareProduct.md
@@ -152,7 +152,7 @@ is_nullable: 0
 
 ```
 data_type: 'text'
-is_nullable: 0
+is_nullable: 1
 ```
 
 ### dimms\_num

--- a/json-schema/device_report.yaml
+++ b/json-schema/device_report.yaml
@@ -5,17 +5,22 @@ $defs:
     $comment: an integer that may be presented as a json string
     type: [ integer, string ]
     pattern: '^[0-9]+$'
-  DeviceReport_v3_0_0:
+  DeviceReport_v3_2_0:
     $comment: the contents of a posted device report from relays and reporters
     type: object
     additionalProperties: true  # there is all kinds of junk in here still
     required:
+      - report_version
       - bios_version
       - product_name
       - sku
       - serial_number
       - system_uuid
     properties:
+      report_version:
+        $comment: future conch-api versions MAY be backwards-compatible to previous report versions, but this is not guaranteed
+        type: string
+        const: 'v3.2'
       bios_version:
         type: string
       cpus:

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -233,7 +233,6 @@ $defs:
       - validation_plan_id
       - purpose
       - bios_firmware
-      - cpu_type
   HardwareProductUpdate:
     type: object
     additionalProperties: false

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -404,6 +404,20 @@ $defs:
         deprecated: true
         title: Number of USBs
         type: integer
+    default:
+      specification: {}
+      cpu_num: 0
+      dimms_num: 0
+      ram_total: 0
+      nics_num: 0
+      sata_hdd_num: 0
+      sas_hdd_num: 0
+      sata_ssd_num: 0
+      psu_total: 0
+      usb_num: 0
+      sas_ssd_num: 0
+      nvme_ssd_num: 0
+      raid_lun_num: 0
   Login:
     type: object
     $ref: '#/$defs/UserIdOrEmail'

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -280,127 +280,127 @@ $defs:
         type: string
         title: Purpose
       bios_firmware:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: BIOS Firmware
         type: string
       hba_firmware:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: HBA Firmware
         type: [ 'null', string ]
       cpu_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of CPUs
         type: integer
       cpu_type:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: CPU Type
         type: string
       dimms_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of DIMMs
         type: integer
       ram_total:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: RAM Total
         type: integer
       nics_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of NICs
         type: integer
       sata_hdd_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of SATA HDDs
         type: integer
       sata_hdd_size:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: SATA HDD Size
         type: [ 'null', integer ]
       sata_hdd_slots:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: SATA HDD Slots
         type: [ 'null', string ]
       sas_hdd_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of SAS HDDs
         type: integer
       sas_hdd_size:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: SAS HDD Size
         type: [ 'null', integer ]
       sas_hdd_slots:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: SAS HDD Slots
         type: [ 'null', string ]
       sata_ssd_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of SATA SSDs
         type: integer
       sata_ssd_size:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: SATA SSD Size
         type: [ 'null', integer ]
       sata_ssd_slots:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: SATA SSD Slots
         type: [ 'null', string ]
       sas_ssd_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of SAS SSDs
         type: integer
       sas_ssd_size:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: SAS SSD Size
         type: [ 'null', integer ]
       sas_ssd_slots:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: SAS SSD Slots
         type: [ 'null', string ]
       nvme_ssd_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of NVME SSDs
         type: integer
       nvme_ssd_size:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: NVME SSD Size
         type: [ 'null', integer ]
       nvme_ssd_slots:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: NVME SSD Slots
         type: [ 'null', string ]
       raid_lun_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of RAID LUNs
         type: integer
       psu_total:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: PSU Total
         type: integer
       usb_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of USBs
         type: integer

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -225,14 +225,18 @@ $defs:
   HardwareProductCreate:
     $ref: '#/$defs/HardwareProductUpdate'
     required:
-      - name
       - alias
       - hardware_vendor_id
-      - sku
       - rack_unit_size
-      - validation_plan_id
       - purpose
-      - bios_firmware
+    anyOf:
+      - required:
+          - name
+          - sku
+          - validation_plan_id
+          - bios_firmware
+      - required:
+          - device_report
   HardwareProductUpdate:
     type: object
     additionalProperties: false
@@ -403,6 +407,9 @@ $defs:
         deprecated: true
         title: Number of USBs
         type: integer
+      device_report:
+        title: Sample passing device report
+        $ref: device_report.yaml#/$defs/DeviceReport_v3_2_0
     default:
       specification: {}
       cpu_num: 0

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -58,7 +58,7 @@ $defs:
       vendor_name:
         $ref: common.yaml#/$defs/mojo_relaxed_placeholder
   DeviceReport:
-    $ref: device_report.yaml#/$defs/DeviceReport_v3_0_0
+    $ref: device_report.yaml#/$defs/DeviceReport_v3_2_0
   RackCreate:
     type: object
     additionalProperties: false

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -705,7 +705,7 @@ $defs:
         $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: CPU Type
-        type: string
+        type: [ 'null', string ]
       dimms_num:
         $comment: this property will be moved into /specification in v3.4
         deprecated: true

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -692,37 +692,37 @@ $defs:
         title: Validation Plan ID
         $ref: common.yaml#/$defs/uuid
       bios_firmware:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: BIOS Firmware
         type: string
       cpu_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of CPUs
         type: integer
       cpu_type:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: CPU Type
         type: string
       dimms_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of DIMMs
         type: integer
       hba_firmware:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: HBA Firmware
         type: [ 'null', string ]
       nics_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of NICs
         type: integer
       psu_total:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: PSU Total
         type: integer
@@ -730,92 +730,92 @@ $defs:
         title: Purpose
         type: string
       ram_total:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: RAM Total
         type: integer
       sas_hdd_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of SAS HDDs
         type: integer
       sas_hdd_size:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: SAS HDD Size
         type: [ 'null', integer ]
       sas_hdd_slots:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: SAS HDD Slots
         type: [ 'null', string ]
       sata_hdd_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of SATA HDDs
         type: integer
       sata_hdd_size:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: SATA HDD Size
         type: [ 'null', integer ]
       sata_hdd_slots:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: SATA HDD Slots
         type: [ 'null', string ]
       sata_ssd_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of SATA SSDs
         type: integer
       sata_ssd_size:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: SATA SSD Size
         type: [ 'null', integer ]
       sata_ssd_slots:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: SATA SSD Slots
         type: [ 'null', string ]
       sas_ssd_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of SAS SSDs
         type: integer
       sas_ssd_size:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: SAS SSD Size
         type: [ 'null', integer ]
       sas_ssd_slots:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: SAS SSD Slots
         type: [ 'null', string ]
       nvme_ssd_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of NVME SSDs
         type: integer
       nvme_ssd_size:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: NVME SSD Size
         type: [ 'null', integer ]
       nvme_ssd_slots:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: NVME SSD Slots
         type: [ 'null', string ]
       raid_lun_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of RAID LUNs
         type: integer
       usb_num:
-        $comment: this property will be moved into /specification in v3.2
+        $comment: this property will be moved into /specification in v3.4
         deprecated: true
         title: Number of USBs
         type: integer

--- a/lib/Conch/Controller/JSONSchema.pm
+++ b/lib/Conch/Controller/JSONSchema.pm
@@ -2,7 +2,6 @@ package Conch::Controller::JSONSchema;
 
 use Mojo::Base 'Mojolicious::Controller', -signatures;
 
-use feature 'current_sub';
 use Mojo::JSON qw(to_json from_json);
 
 =pod

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -6,7 +6,6 @@ use Conch::UUID 'is_uuid';
 use Email::Valid;
 use List::Util 'pairmap';
 use Authen::Passphrase::RejectAll;
-use feature 'fc';
 
 =pod
 

--- a/lib/Conch/DB/Result/HardwareProduct.pm
+++ b/lib/Conch/DB/Result/HardwareProduct.pm
@@ -133,7 +133,7 @@ __PACKAGE__->table("hardware_product");
 =head2 cpu_type
 
   data_type: 'text'
-  is_nullable: 0
+  is_nullable: 1
 
 =head2 dimms_num
 
@@ -306,7 +306,7 @@ __PACKAGE__->add_columns(
   "cpu_num",
   { data_type => "integer", default_value => 0, is_nullable => 0 },
   "cpu_type",
-  { data_type => "text", is_nullable => 0 },
+  { data_type => "text", is_nullable => 1 },
   "dimms_num",
   { data_type => "integer", default_value => 0, is_nullable => 0 },
   "ram_total",
@@ -457,7 +457,7 @@ __PACKAGE__->has_many(
 
 
 # Created by DBIx::Class::Schema::Loader v0.07049
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:5AVC0Uc3etwanzij1PM+fQ
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:4kFA0vtW1WRO8vyYhQH/+w
 
 use experimental 'signatures';
 use Mojo::JSON 'from_json';

--- a/lib/Conch/Plugin/JSONValidator.pm
+++ b/lib/Conch/Plugin/JSONValidator.pm
@@ -2,7 +2,6 @@ package Conch::Plugin::JSONValidator;
 
 use Mojo::Base 'Mojolicious::Plugin', -signatures;
 
-use feature 'unicode_strings';
 use JSON::Schema::Draft201909 '0.020';
 use YAML::PP;
 use Mojo::JSON 'to_json';

--- a/lib/Conch/Route.pm
+++ b/lib/Conch/Route.pm
@@ -2,8 +2,6 @@ package Conch::Route;
 
 use Mojo::Base -strict, -signatures;
 use List::Util qw(uniqstr any);
-use feature 'state';
-use feature 'current_sub';
 
 use Conch::UUID;
 use Conch::Route::JSONSchema;

--- a/lib/Conch/Route/HardwareProduct.pm
+++ b/lib/Conch/Route/HardwareProduct.pm
@@ -45,7 +45,8 @@ sub routes {
     # POST /hardware_product
     $hardware_product->require_system_admin
       ->under($check_for_changed_specification_schema)
-      ->post('/')->to('#create', request_schema => 'HardwareProductCreate');
+      ->under('/')->to('#extract_from_device_report', request_schema => 'HardwareProductCreate')
+      ->post('/')->to('#create');
 
     {
         $hardware_product->any('/<:hardware_product_key>=<:hardware_product_value>/*optional',
@@ -69,7 +70,8 @@ sub routes {
         # POST /hardware_product/:hardware_product_id_or_other
         $hwp_with_admin
           ->under($check_for_changed_specification_schema)
-          ->post('/')->to('#update', request_schema => 'HardwareProductUpdate');
+          ->under('/')->to('#extract_from_device_report', request_schema => 'HardwareProductUpdate')
+          ->post('/')->to('#update');
 
         # DELETE /hardware_product/:hardware_product_id_or_other
         $hwp_with_admin->delete('/')->to('#delete');

--- a/lib/Test/Conch/Validation.pm
+++ b/lib/Test/Conch/Validation.pm
@@ -226,7 +226,7 @@ sub _test_case {
     if (not Test::Builder->new->is_passing) {
         require Data::Dumper;
         diag 'all results: ',
-            Data::Dumper->new([ [ $validation->legacy_validation_results ] ])->Indent(1)->Terse(1)->Dump;
+            Data::Dumper->new([ [ $validation->validation_results ] ])->Indent(1)->Terse(1)->Dump;
     }
 }
 

--- a/sql/migrations/0186-hardware_product-unused-columns.sql
+++ b/sql/migrations/0186-hardware_product-unused-columns.sql
@@ -1,0 +1,6 @@
+SELECT run_migration(186, $$
+
+  alter table hardware_product alter column cpu_type drop not null;
+  update hardware_product set cpu_type = null where cpu_type = '' or cpu_type = 'unknown';
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -390,7 +390,7 @@ CREATE TABLE public.hardware_product (
     bios_firmware text NOT NULL,
     hba_firmware text,
     cpu_num integer DEFAULT 0 NOT NULL,
-    cpu_type text NOT NULL,
+    cpu_type text,
     dimms_num integer DEFAULT 0 NOT NULL,
     ram_total integer DEFAULT 0 NOT NULL,
     nics_num integer DEFAULT 0 NOT NULL,

--- a/t/integration/crud/hardware-product.t
+++ b/t/integration/crud/hardware-product.t
@@ -52,13 +52,13 @@ $t->post_ok('/hardware_product', json => { wat => 'wat' })
     ->json_schema_is('RequestValidationError')
     ->json_cmp_deeply('/details', [
         superhashof({ error => 'additional property not permitted' }),
-        superhashof({ error => 'missing properties: name, alias, hardware_vendor_id, sku, rack_unit_size, validation_plan_id, purpose, bios_firmware, cpu_type' }),
+        superhashof({ error => 'missing properties: name, alias, hardware_vendor_id, sku, rack_unit_size, validation_plan_id, purpose, bios_firmware' }),
     ]);
 
 $t->post_ok('/hardware_product', json => { name => 'sungo', alias => 'sungo' })
     ->status_is(400)
     ->json_schema_is('RequestValidationError')
-    ->json_cmp_deeply('/details', [ superhashof({ error => 'missing properties: hardware_vendor_id, sku, rack_unit_size, validation_plan_id, purpose, bios_firmware, cpu_type' }) ]);
+    ->json_cmp_deeply('/details', [ superhashof({ error => 'missing properties: hardware_vendor_id, sku, rack_unit_size, validation_plan_id, purpose, bios_firmware' }) ]);
 
 my %hw_fields = (
     name => 'sungo',
@@ -69,7 +69,6 @@ my %hw_fields = (
     validation_plan_id => $validation_plan_id,
     purpose => 'myself',
     bios_firmware => '1.2.3',
-    cpu_type => 'fooey',
 );
 
 $t->post_ok('/hardware_product', json => { %hw_fields, specification => 'not json!' } )
@@ -149,6 +148,7 @@ $t->get_ok($t->tx->res->headers->location)
         legacy_product_name => undef,
         hba_firmware => undef,
         cpu_num => 0,
+        cpu_type => undef,
         dimms_num => 0,
         ram_total => 0,
         nics_num => 0,
@@ -189,7 +189,6 @@ $t->post_ok('/hardware_product', json => {
         validation_plan_id => $validation_plan_id,
         purpose => 'nothing',
         bios_firmware => '0',
-        cpu_type => 'cold',
     })
     ->status_is(409)
     ->json_schema_is('Error')
@@ -204,7 +203,6 @@ $t->post_ok('/hardware_product', json => {
         validation_plan_id => $validation_plan_id,
         purpose => 'nothing',
         bios_firmware => '0',
-        cpu_type => 'cold',
     })
     ->status_is(409)
     ->json_schema_is('Error')
@@ -219,7 +217,6 @@ $t->post_ok('/hardware_product', json => {
         validation_plan_id => create_uuid_str(),
         purpose => 'nothing',
         bios_firmware => '0',
-        cpu_type => 'cold',
     })
     ->status_is(409)
     ->json_schema_is('Error')
@@ -318,7 +315,6 @@ $t->post_ok('/hardware_product', json => {
         validation_plan_id => $validation_plan_id,
         purpose => 'myself',
         bios_firmware => '1.2.3',
-        cpu_type => 'fooey',
     })
     ->status_is(201)
     ->location_like(qr!^/hardware_product/${\Conch::UUID::UUID_FORMAT}$!);

--- a/t/integration/crud/hardware-product.t
+++ b/t/integration/crud/hardware-product.t
@@ -52,13 +52,19 @@ $t->post_ok('/hardware_product', json => { wat => 'wat' })
     ->json_schema_is('RequestValidationError')
     ->json_cmp_deeply('/details', [
         superhashof({ error => 'additional property not permitted' }),
-        superhashof({ error => 'missing properties: name, alias, hardware_vendor_id, sku, rack_unit_size, validation_plan_id, purpose, bios_firmware' }),
+        superhashof({ error => 'missing properties: alias, hardware_vendor_id, rack_unit_size, purpose' }),
+        superhashof({ error => 'missing properties: name, sku, validation_plan_id, bios_firmware' }),
+        superhashof({ error => 'missing property: device_report' }),
     ]);
 
 $t->post_ok('/hardware_product', json => { name => 'sungo', alias => 'sungo' })
     ->status_is(400)
     ->json_schema_is('RequestValidationError')
-    ->json_cmp_deeply('/details', [ superhashof({ error => 'missing properties: hardware_vendor_id, sku, rack_unit_size, validation_plan_id, purpose, bios_firmware' }) ]);
+    ->json_cmp_deeply('/details', [
+        superhashof({ error => 'missing properties: hardware_vendor_id, rack_unit_size, purpose' }),
+        superhashof({ error => 'missing properties: sku, validation_plan_id, bios_firmware' }),
+        superhashof({ error => 'missing property: device_report' }),
+    ]);
 
 my %hw_fields = (
     name => 'sungo',
@@ -221,6 +227,130 @@ $t->post_ok('/hardware_product', json => {
     ->status_is(409)
     ->json_schema_is('Error')
     ->json_is({ error => 'validation_plan_id does not exist' });
+
+$t->post_ok('/hardware_product', json => {
+    alias => 'another alias',
+    hardware_vendor_id => $vendor_id,
+    rack_unit_size => 1,
+    purpose => 'nothing',
+  })
+  ->status_is(400)
+  ->json_schema_is('RequestValidationError')
+  ->json_cmp_deeply('/details', [
+    {
+      data_location => '',
+      schema_location => '/anyOf/0/required',
+      absolute_schema_location => $base_uri.'json_schema/request/HardwareProductCreate#/anyOf/0/required',
+      error => 'missing properties: name, sku, validation_plan_id, bios_firmware',
+    },
+    {
+      data_location => '',
+      schema_location => '/anyOf/1/required',
+      absolute_schema_location => $base_uri.'json_schema/request/HardwareProductCreate#/anyOf/1/required',
+      error => 'missing property: device_report',
+    },
+  ]);
+
+$t->post_ok('/hardware_product', json => my $args ={
+    alias => 'another alias',
+    hardware_vendor_id => $vendor_id,
+    rack_unit_size => 1,
+    purpose => 'my purpose',
+    device_report => {
+      report_version => 'v3.2',
+      bios_version => 'my bios',
+      product_name => 'my product name',
+      sku => 'another sku',
+      serial_number => 'my_serial',
+      system_uuid => create_uuid_str,
+      # no device_type, and 'server' plan does not exist
+      cpus => [ {} ],
+      dimms => [
+        { 'memory-locator' => '' },
+        { 'memory-locator' => '', 'memory-size' => 20 },
+        { 'memory-locator' => '', 'memory-type' => undef },
+      ],
+      interfaces => {
+        foo => { mac => '00:00:00:00:00:00', product => '', vendor => '' },
+        bar => { mac => '00:00:00:00:00:00', product => '', vendor => '' },
+        baz => { mac => '00:00:00:00:00:00', product => '', vendor => '' },
+      },
+      disks => {
+        a => {},
+        b => { drive_type => 'NVME_SSD' },
+        c => { drive_type => 'RAID_LUN' },
+        d => { drive_type => 'SAS_HDD' },
+        e => { drive_type => 'SAS_SSD' },
+        f => { drive_type => 'SATA_HDD' },
+        g => { drive_type => 'SATA_SSD' },
+        h => { transport => 'usb' },
+      },
+    },
+  })
+  ->status_is(409)
+  ->json_schema_is('Error')
+  ->json_is({ error => 'cannot determine validation_plan_id from device_type' });
+
+$args->{device_report}{device_type} = 'server';
+$t->post_ok('/hardware_product', json => $args)
+  ->status_is(409)
+  ->json_schema_is('Error')
+  ->json_is({ error => 'cannot determine validation_plan_id from device_type' });
+
+my $server_plan = $t->app->db_legacy_validation_plans->create({ name => 'The Server Plan', description => 'hi' });
+
+$t->post_ok('/hardware_product', json => $args)
+  ->status_is(201)
+  ->location_like(qr!^/hardware_product/${\Conch::UUID::UUID_FORMAT}$!);
+
+$t->get_ok($t->tx->res->headers->location)
+  ->status_is(200)
+  ->json_schema_is('HardwareProduct')
+  ->json_cmp_deeply({
+    name => 'my product name',
+    hardware_vendor_id => $vendor_id,
+    alias => 'another alias',
+    rack_unit_size => 1,
+    sku => 'another sku',
+    purpose => 'my purpose',
+    bios_firmware => 'my bios',
+    id => re(Conch::UUID::UUID_FORMAT),
+    validation_plan_id => $server_plan->id,
+    prefix => undef,
+    specification => {},
+    created => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
+    updated => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
+    generation_name => undef,
+    legacy_product_name => undef,
+    hba_firmware => undef,
+    cpu_num => 1,
+    cpu_type => undef,
+    dimms_num => 1,
+    ram_total => 20,
+    nics_num => 3,
+    nvme_ssd_num => 1,
+    nvme_ssd_size => undef,
+    nvme_ssd_slots => undef,
+    raid_lun_num => 1,
+    sas_hdd_num => 1,
+    sas_hdd_size => undef,
+    sas_hdd_slots => undef,
+    sas_ssd_num => 1,
+    sas_ssd_size => undef,
+    sas_ssd_slots => undef,
+    sata_hdd_num => 1,
+    sata_hdd_size => undef,
+    sata_hdd_slots => undef,
+    sata_ssd_num => 1,
+    sata_ssd_size => undef,
+    sata_ssd_slots => undef,
+    psu_total => 0,
+    usb_num => 1,
+  });
+
+$t->delete_ok('/hardware_product/'.$t->tx->res->json->{id})
+  ->status_is(204);
+
 
 $t->post_ok("/hardware_product/$new_hw_id", json => { specification => 'not json!' })
     ->status_is(400)

--- a/t/integration/device-reports.t
+++ b/t/integration/device-reports.t
@@ -296,7 +296,7 @@ subtest 'save reports for device' => sub {
             json => { foo => 'this 1s v@l,d ǰsøƞ, but violates the schema' })
         ->status_is(400)
         ->json_schema_is('RequestValidationError')
-        ->json_cmp_deeply('/details', [ superhashof({ error => 'missing properties: bios_version, product_name, sku, serial_number, system_uuid' }) ]);
+        ->json_cmp_deeply('/details', [ superhashof({ error => 'missing properties: report_version, bios_version, product_name, sku, serial_number, system_uuid' }) ]);
 
     is($device->related_resultset('device_reports')->count, 2, 'still just two device_report rows exist');
     is($device->related_resultset('validation_states')->count, 2, 'still just two validation_state rows exist');

--- a/t/integration/device-validations.t
+++ b/t/integration/device-validations.t
@@ -97,7 +97,7 @@ subtest 'test validating a device' => sub {
     $t->post_ok("/device/TEST/validation/$validation_id", json => {})
         ->status_is(400)
         ->json_schema_is('RequestValidationError')
-        ->json_cmp_deeply('/details', [ superhashof({ error => 'missing properties: bios_version, product_name, sku, serial_number, system_uuid' }) ]);
+        ->json_cmp_deeply('/details', [ superhashof({ error => 'missing properties: report_version, bios_version, product_name, sku, serial_number, system_uuid' }) ]);
 
     $t->post_ok("/device/TEST/validation/$validation_id",
             { 'Content-Type' => 'application/json' }, $good_report)
@@ -112,7 +112,7 @@ subtest 'test validating a device' => sub {
     $t->post_ok('/device/TEST/validation_plan/'.$test_validation_plan->id, json => {})
         ->status_is(400)
         ->json_schema_is('RequestValidationError')
-        ->json_cmp_deeply('/details', [ superhashof({ error => 'missing properties: bios_version, product_name, sku, serial_number, system_uuid' }) ]);
+        ->json_cmp_deeply('/details', [ superhashof({ error => 'missing properties: report_version, bios_version, product_name, sku, serial_number, system_uuid' }) ]);
 
     $t->post_ok('/device/TEST/validation_plan/'.$test_validation_plan->id,
             { 'Content-Type' => 'application/json' }, $good_report)

--- a/t/integration/json_schema-unauthed.t
+++ b/t/integration/json_schema-unauthed.t
@@ -264,11 +264,11 @@ $t->get_ok('/json_schema/request/DeviceReport')
     ->json_cmp_deeply(superhashof({
         '$schema' => SPEC_URL,
         '$id' => re(qr{/json_schema/request/DeviceReport$}),
-        '$ref' => '/json_schema/device_report/DeviceReport_v3_0_0',
+        '$ref' => '/json_schema/device_report/DeviceReport_v3_2_0',
         '$defs' => superhashof({
-            'DeviceReport_v3_0_0' => superhashof({
+            'DeviceReport_v3_2_0' => superhashof({
                 '$comment' => ignore,
-                '$id' => '/json_schema/device_report/DeviceReport_v3_0_0',
+                '$id' => '/json_schema/device_report/DeviceReport_v3_2_0',
                 properties => superhashof({}),
                 required => superbagof(),
             }),
@@ -292,12 +292,12 @@ $t->get_ok('/json_schema/common/non_zero_uuid')
         },
     });
 
-$t->get_ok('/json_schema/device_report/DeviceReport_v3_0_0')
+$t->get_ok('/json_schema/device_report/DeviceReport_v3_2_0')
     ->status_is(200)
     ->header_is('Content-Type', 'application/schema+json')
     ->json_schema_is('JSONSchemaOnDisk')
     ->json_cmp_deeply({
-        '$id' => $base_uri.'json_schema/device_report/DeviceReport_v3_0_0',
+        '$id' => $base_uri.'json_schema/device_report/DeviceReport_v3_2_0',
         '$schema' => SPEC_URL,
         '$comment' => ignore,
         type => 'object',

--- a/t/integration/json_schema-unauthed.t
+++ b/t/integration/json_schema-unauthed.t
@@ -153,24 +153,6 @@ $t->get_ok('/json_schema/query_params/ResetUserPassword')
         },
     });
 
-$t->get_ok('/json_schema/request/HardwareProductCreate')
-    ->status_is(200)
-    ->header_is('Content-Type', 'application/schema+json')
-    ->json_schema_is('JSONSchemaOnDisk')
-    ->json_cmp_deeply('', superhashof({
-        '$schema' => SPEC_URL,
-        '$id' => $base_uri.'json_schema/request/HardwareProductCreate',
-        '$defs' => {
-            map +($_ => superhashof({})), qw(
-                uuid
-                positive_integer
-                non_empty_string
-                mojo_standard_placeholder
-                HardwareProductUpdate
-            )
-        },
-    }), 'nested definitions are found and included');
-
 $t->get_ok('/json_schema/request/HardwareProductUpdate')
     ->status_is(200)
     ->header_is('Content-Type', 'application/schema+json')
@@ -186,7 +168,7 @@ $t->get_ok('/json_schema/request/HardwareProductUpdate')
           '$ref' => '/json_schema/hardware_product/specification/latest',
         },
       }),
-    }), 'reference to hardware_product specification is contained');
+    }), 'reference to hardware_product specification is retained');
 
 $t->get_ok('/json_schema/response/JSONSchemaOnDisk')
     ->status_is(200)

--- a/t/integration/resource/error-device-report.json
+++ b/t/integration/resource/error-device-report.json
@@ -1,4 +1,5 @@
 {
+  "report_version": "v3.2",
   "health": "PASS",
   "bios_version": "2.4.3",
   "memory": {

--- a/t/integration/resource/passing-device-report.json
+++ b/t/integration/resource/passing-device-report.json
@@ -1,4 +1,5 @@
 {
+  "report_version": "v3.2",
   "health": "PASS",
   "bios_version": "2.4.3",
   "memory": {

--- a/t/json-validation.t
+++ b/t/json-validation.t
@@ -126,7 +126,7 @@ subtest 'device report validation' => sub {
 
     cmp_deeply(
         $validator->evaluate('00000000-0000-0000-0000-000000000000',
-            'device_report.yaml#/$defs/DeviceReport_v3_0_0/properties/system_uuid')->TO_JSON,
+            'device_report.yaml#/$defs/DeviceReport_v3_2_0/properties/system_uuid')->TO_JSON,
         {
             valid => JSON::PP::false,
             errors => [
@@ -143,7 +143,7 @@ subtest 'device report validation' => sub {
 
     cmp_deeply(
         $validator->evaluate({ '' => {} },
-            'device_report.yaml#/$defs/DeviceReport_v3_0_0/properties/disks')->TO_JSON,
+            'device_report.yaml#/$defs/DeviceReport_v3_2_0/properties/disks')->TO_JSON,
         {
             valid => JSON::PP::false,
             errors => [


### PR DESCRIPTION
- add a mandatory "report_version" property to device reports
- cpu_type is made optional in reports and nullable in the database
- allow supplying a sample (passing) device report to the hardware_product creation and update endpoints, to infer data where we can from that report rather than having to supply it diirectly (direct overrides are still allowed)

closes #1086.